### PR TITLE
Allow followup buttons to be handled without adding a prompt into the chat

### DIFF
--- a/src/components/chat-item/chat-item-followup.ts
+++ b/src/components/chat-item/chat-item-followup.ts
@@ -34,15 +34,17 @@ export class ChatItemFollowUpContainer {
               children: [ followUpOption.pillText ],
               events: {
                 click: (e) => {
-                  MynahUIDataStore.getInstance().updateStore({
-                    chatItems: [
-                      ...MynahUIDataStore.getInstance().getValue('chatItems'),
-                      {
-                        type: ChatItemType.PROMPT,
-                        body: `<span>${followUpOption.prompt}</span>`,
-                      }
-                    ]
-                  });
+                  if (followUpOption.prompt != null) {
+                    MynahUIDataStore.getInstance().updateStore({
+                      chatItems: [
+                        ...MynahUIDataStore.getInstance().getValue('chatItems'),
+                        {
+                          type: ChatItemType.PROMPT,
+                          body: `<span>${followUpOption.prompt}</span>`,
+                        }
+                      ]
+                    });
+                  }
                   MynahUIGlobalEvents.getInstance().dispatch(MynahEventNames.FOLLOW_UP_CLICKED, followUpOption);
 
                   this.render.remove();

--- a/src/static.ts
+++ b/src/static.ts
@@ -142,7 +142,7 @@ export interface ChatItem {
 }
 
 export interface ChatPrompt {
-  prompt: string;
+  prompt?: string;
   attachment?: Suggestion;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently every time you click a follow up button it sends a prompt to the chat and sends the FOLLOW_UP_CLICKED event. However, there are use cases in Weaverbird where we want to have follow up buttons that aren't technically tied to the chat but instead, have the onFollowUpClicked be called without a chat message.

For example, after code generation happens we present the user with two follow up buttons: accept the changes and deny the changes. When the user clicks the accept changes/deny changes button we want to handle those without having to add any text into the chat


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
