### PR TITLE
Fixed selected code snippet styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "2.0.0-beta.15.2",
+  "version": "2.0.0-beta.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "2.0.0-beta.15.2",
+      "version": "2.0.0-beta.15.3",
       "license": "Apache License 2.0",
       "dependencies": {
         "escape-html": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "2.0.0-beta.15.2",
+  "version": "2.0.0-beta.15.3",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/components/chat-item/prompt-input/code-snippet.ts
+++ b/src/components/chat-item/prompt-input/code-snippet.ts
@@ -38,6 +38,11 @@ export class CodeSnippet {
           markdownText: selectedCodeSnippet,
         }).render
       );
+      const isCodeOverflowVertically =
+        (this._render.getBoundingClientRect()?.height ?? 0) < (this._render.getElementsByTagName('code')?.[0]?.getBoundingClientRect()?.height ?? 0);
+      if (isCodeOverflowVertically) {
+        this._render.children[0].classList.add('vertical-overflow');
+      }
     }
     MynahUITabsStore.getInstance().getTabDataStore(this._props.tabId).updateStore({
       selectedCodeSnippet,

--- a/src/main.ts
+++ b/src/main.ts
@@ -189,15 +189,9 @@ export class MynahUI {
       }
     });
 
-    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.CHAT_ITEM_ENGAGEMENT, (data: {
-      engagement: Engagement; messageId: string;
-    }) => {
+    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.CHAT_ITEM_ENGAGEMENT, (data: { engagement: Engagement; messageId: string }) => {
       if (this.props.onChatItemEngagement !== undefined) {
-        this.props.onChatItemEngagement(
-          MynahUITabsStore.getInstance().getSelectedTabId(),
-          data.messageId,
-          data.engagement
-        );
+        this.props.onChatItemEngagement(MynahUITabsStore.getInstance().getSelectedTabId(), data.messageId, data.engagement);
       }
     });
 

--- a/src/styles/components/chat/_chat-prompt-code-snippet.scss
+++ b/src/styles/components/chat/_chat-prompt-code-snippet.scss
@@ -5,6 +5,13 @@
   }
 }
 
+.snippet-card-container.vertical-overflow {
+  & pre {
+    // Show fading effect at the bottom when overflowing
+    @include list-fader-bottom(var(--mynah-sizing-16));
+  }
+}
+
 .snippet-card-container {
   max-width: calc(5 * var(--mynah-sizing-18));
   max-height: var(--mynah-sizing-10);
@@ -29,14 +36,14 @@
   }
   > .mynah-card-body > .mynah-syntax-highlighter {
     border: none;
-    > pre {
-      @include list-fader-bottom();
+    & pre {
+      text-overflow: ellipsis;
     }
   }
 }
 
 .snippet-card-container-preview {
-  max-width: 70vw;
+  max-width: 80vw;
   max-height: 70vh;
   > .mynah-card-body {
     > .mynah-syntax-highlighter {
@@ -62,5 +69,8 @@
         display: none;
       }
     }
+  }
+  & pre {
+    text-overflow: ellipsis;
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
- Selected code snippet always show fading effect at the bottom, even if the height is not overflowing

*Description of changes:*
- Now selected code snippet only shows fading effect if the height is overflowing
- Show ellipsis if the line is overflowing horizontally (line being too long)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
