### PR TITLE
dogusata/add all tabs and stores return to main

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,8 +8,7 @@ node_modules/**
 **/jest.config.js
 **/webpack.config.js
 dist/**
-example/dist/**
-example/src/index.html
+example/**
 docs/**
 out/**
 *.config.js

--- a/example/src/index.html
+++ b/example/src/index.html
@@ -1,7 +1,6 @@
 <html theme="light+">
 
 <head>
-    <link rel="icon" href="../mynah-logo.svg" type="image/svg+xml">
 </head>
 
 <body>

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -120,13 +120,6 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
               type: ChatItemType.PROMPT,
               messageId: new Date().getTime().toString(),
               body: `**${prompt.command.replace('/', '')}**\n${prompt.escapedPrompt as string}`,
-              ...(prompt.attachment !== undefined
-                ? {
-                    relatedContent: {
-                      content: [ prompt.attachment ]
-                    }
-                  }
-                : {})
             });
             getGenerativeAIAnswer(tabId, prompt);
             break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "Apache License 2.0",
       "dependencies": {
         "@babel/core": "^7.23.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/components/chat-item/chat-item-card.ts
+++ b/src/components/chat-item/chat-item-card.ts
@@ -252,6 +252,19 @@ export class ChatItemCard {
           ...updateWith,
         };
 
+        // Update item inside the store
+        if (this.props.chatItem.messageId !== undefined) {
+          const currentTabChatItems = MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId)?.getStore()?.chatItems;
+          MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).updateStore({
+            chatItems: currentTabChatItems?.map((chatItem: ChatItem) => {
+              if (chatItem.messageId === this.props.chatItem.messageId) {
+                return this.props.chatItem;
+              }
+              return chatItem;
+            })
+          }, true);
+        }
+
         const newCardContent = this.getCardContent();
         const upcomingWords = Array.from(this.contentBody.render.querySelectorAll('.typewriter-part'));
         for (let i = 0; i < upcomingWords.length; i++) {

--- a/src/helper/store.ts
+++ b/src/helper/store.ts
@@ -56,6 +56,11 @@ export class MynahUIDataStore {
   public getDefaults = (): MynahUIDataModel | null => this.defaults;
 
   /**
+   * Get the current store data
+   */
+  public getStore = (): MynahUIDataModel | null => this.store;
+
+  /**
    * Subscribe to value changes of a specific item in data store
    * @param storeKey One of the keys in MynahUIDataModel
    * @param handler function will be called when value of the given key is updated in store with new and old values

--- a/src/helper/tabs-store.ts
+++ b/src/helper/tabs-store.ts
@@ -187,7 +187,13 @@ export class MynahUITabsStore {
    * @param tabId Tab Id
    * @returns info of the tab
    */
-  public getAllTabs = (): MynahUITabStoreModel => structuredClone(this.tabsStore);
+  public getAllTabs = (): MynahUITabStoreModel => {
+    const clonedTabs = structuredClone(this.tabsStore) as MynahUITabStoreModel;
+    Object.keys(clonedTabs).forEach(tabId => {
+      clonedTabs[tabId].store = structuredClone(this.getTabDataStore(tabId).getStore()) ?? {};
+    });
+    return clonedTabs;
+  };
 
   /**
    * Returns the data store of the tab

--- a/src/main.ts
+++ b/src/main.ts
@@ -338,6 +338,12 @@ export class MynahUI {
   };
 
   /**
+   * Returns all tabs with their store information
+   * @returns string selectedTabId or undefined
+   */
+  public getAllTabs = (): MynahUITabStoreModel => MynahUITabsStore.getInstance().getAllTabs();
+
+  /**
    * Simply creates and shows a notification
    * @param props NotificationProps
    */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,9 +21,10 @@
 		],
 		"strictPropertyInitialization": false,
 	},
-	// "include": ["src/**/*.d.ts", "./.eslintrc.js"],
 	"exclude": [
 		"dist",
-		"node_modules"
+		"node_modules",
+		"docs",
+		"example"
 	]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ const config = {
       { test: /\.scss$/, use: ['style-loader', 'css-loader', 'sass-loader'] },
       {
         test: /\.ts$/,
-        exclude: /node_modules/,
+        exclude: [/node_modules/, /.\/example/],
         use: [
           {
             loader: 'ts-loader',


### PR DESCRIPTION
## Problem
It was not possible to get the all tabs data and their store information but it is crucial for test purposes on the projects which uses mynah-ui
## Solution
added `getAllTabs` function to main class, which all tab items also include the latest and updated store information including the chatItems with updated streams.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
