### PR TITLE
Dogusata/marked and typewriter animations improvements

### DIFF
--- a/example/src/samples/sample-list-0.md
+++ b/example/src/samples/sample-list-0.md
@@ -1,6 +1,1 @@
 This is a list below with some code and bolds inside
-
-- **Bold** Text with some `inline code`.
-- Also with some code blocks ```const a = 5;```
-
-End of the list.

--- a/example/src/samples/sample-list-1.md
+++ b/example/src/samples/sample-list-1.md
@@ -4,10 +4,3 @@ This is a list below with some code and bolds inside
 - Also with some code blocks ```const a = 5;```
 
 End of the list.
-
-Certainly, here's an example of a Markdown list where each item has a bold text word:
-
-* **Item1** This is the first list item.
-* **Item2** This is the second list item.
-* **Item3** This is the third list item.
-* **Item4** This is the fourth list item. And it also has a [LINK](#) inside.

--- a/example/src/samples/sample-list-2.md
+++ b/example/src/samples/sample-list-2.md
@@ -5,13 +5,6 @@ This is a list below with some code and bolds inside
 
 End of the list.
 
-Certainly, here's an example of a Markdown list where each item has a bold text word:
-
-* **Item1** This is the first list item.
-* **Item2** This is the second list item.
-* **Item3** This is the third list item.
-* **Item4** This is the fourth list item. And it also has a [LINK](#) inside.
-
 List with numbers.
 1. **Item1** This is the first list item.
 2. **Item2** This is the second list item.

--- a/example/src/samples/sample-list-3.md
+++ b/example/src/samples/sample-list-3.md
@@ -5,23 +5,19 @@ This is a list below with some code and bolds inside
 
 End of the list.
 
-Certainly, here's an example of a Markdown list where each item has a bold text word:
-
-* **Item1** This is the first list item.
-* **Item2** This is the second list item.
-* **Item3** This is the third list item.
-* **Item4** This is the fourth list item. And it also has a [LINK](#) inside.
-
 List with numbers.
 1. **Item1** This is the first list item.
 2. **Item2** This is the second list item.
 3. **Item3** This is the third list item.
 4. **Item4** This is the fourth list item. And it also has a [LINK](#) inside.
 
-To create this in Markdown, you would use the following syntax:\`\`\`
-* **Item1** This is the first list item.
-* **Item2** This is the second list item.
-* **Item3** This is the third list item.
-* **Item4** This is the fourth list item.
-\`\`\`
+To create a code **block** in Markdown, you would use the triple backticks (\`\`\`) with following syntax:
+
+> \`\`\`
+> let a = 5;
+> console.log(a);
+> a = a + 5;
+> console.log(a);
+> \`\`\`
+
 The asterisk `*` creates an unordered list item, and the double asterisks `**text**` wrap the text you want to make bold. [[1]](https://aasiyaonize.hashnode.dev/markdown-and-restructured)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.7.1",
+  "version": "4.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.7.1",
+      "version": "4.8.0",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {
         "just-clone": "^6.2.0",
-        "marked": "^7.0.3",
+        "marked": "^12.0.2",
         "prismjs": "1.29.0",
         "sanitize-html": "^2.12.1",
         "unescape-html": "^1.1.0"
@@ -24,7 +24,6 @@
         "@types/glob": "7.1.3",
         "@types/jest": "^29.5.5",
         "@types/json-schema": "7.0.7",
-        "@types/marked": "^5.0.1",
         "@types/node": "17.0.29",
         "@types/prismjs": "^1.26.2",
         "@types/sanitize-html": "^2.11.0",
@@ -1731,12 +1730,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
-    },
-    "node_modules/@types/marked": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.2.tgz",
-      "integrity": "sha512-OucS4KMHhFzhz27KxmWg7J+kIYqyqoW5kdIEI319hqARQQUTqhao3M/F+uFnDXD0Rg72iDDZxZNxq5gvctmLlg==",
       "dev": true
     },
     "node_modules/@types/minimatch": {
@@ -7581,14 +7574,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-7.0.5.tgz",
-      "integrity": "sha512-lwNAFTfXgqpt/XvK17a/8wY9/q6fcSPZT1aP6QW0u74VwaJF/Z9KbRcX23sWE4tODM+AolJNcUtErTkgOeFP/Q==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 18"
       }
     },
     "node_modules/merge-stream": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.7.1",
+  "version": "4.8.0",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "just-clone": "^6.2.0",
-    "marked": "^7.0.3",
+    "marked": "^12.0.2",
     "prismjs": "1.29.0",
     "sanitize-html": "^2.12.1",
     "unescape-html": "^1.1.0"
@@ -36,7 +36,6 @@
     "@types/glob": "7.1.3",
     "@types/jest": "^29.5.5",
     "@types/json-schema": "7.0.7",
-    "@types/marked": "^5.0.1",
     "@types/node": "17.0.29",
     "@types/prismjs": "^1.26.2",
     "@types/sanitize-html": "^2.11.0",

--- a/src/components/button.ts
+++ b/src/components/button.ts
@@ -42,7 +42,7 @@ export class Button {
         ...(props.tooltip != null
           ? {
               mouseover: (e) => {
-                const tooltipText = marked(props.tooltip ?? '', { breaks: true });
+                const tooltipText = marked(props.tooltip ?? '', { breaks: true }) as string;
                 this.showButtonTooltip(tooltipText, props.tooltipVerticalDirection, props.tooltipHorizontalDirection);
               },
               mouseleave: this.hideButtonTooltip

--- a/src/components/chat-item/chat-item-followup-option.ts
+++ b/src/components/chat-item/chat-item-followup-option.ts
@@ -52,7 +52,7 @@ export class ChatItemFollowUpOption {
           : []),
         {
           type: 'span',
-          innerHTML: marked(croppedPillText, { breaks: true }).replace('<p>', '').replace('</p>', '')
+          innerHTML: (marked(croppedPillText, { breaks: true }) as string).replace('<p>', '').replace('</p>', '')
         }
       ],
       events: {
@@ -65,7 +65,7 @@ export class ChatItemFollowUpOption {
         ...(props.followUpOption.pillText.length > MAX_LENGTH || props.followUpOption.description !== undefined
           ? {
               mouseover: (e) => {
-                let tooltipText = marked(props.followUpOption.pillText.length > MAX_LENGTH ? props.followUpOption.pillText : '', { breaks: true });
+                let tooltipText = marked(props.followUpOption.pillText.length > MAX_LENGTH ? props.followUpOption.pillText : '', { breaks: true }) as string;
                 if (props.followUpOption.description !== undefined) {
                   if (tooltipText !== '') {
                     tooltipText += '\n\n';

--- a/src/components/no-tabs.ts
+++ b/src/components/no-tabs.ts
@@ -29,7 +29,7 @@ export class NoTabs {
         {
           type: 'div',
           classNames: [ 'mynah-no-tabs-info' ],
-          innerHTML: marked(Config.getInstance().config.texts.noTabsOpen ?? '', { breaks: true })
+          innerHTML: marked(Config.getInstance().config.texts.noTabsOpen ?? '', { breaks: true }) as string
         },
         {
           type: 'div',

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import { ChatWrapper } from './components/chat-item/chat-wrapper';
 import { FeedbackForm } from './components/feedback-form/feedback-form';
 import { MynahUITabsStore } from './helper/tabs-store';
 import { Config } from './helper/config';
+import { marked } from 'marked';
 import './styles/styles.scss';
 import { generateUID } from './helper/guid';
 import { NoTabs } from './components/no-tabs';
@@ -204,6 +205,13 @@ export class MynahUI {
   private readonly chatWrappers: Record<string, ChatWrapper> = {};
 
   constructor (props: MynahUIProps) {
+    // Apply global fix for marked listitem content is not getting parsed.
+    marked.use({
+      renderer: {
+        listitem: (src) => `<li>${marked.parse(src, { breaks: true }) as string}</li>`
+      },
+    });
+
     this.props = props;
     Config.getInstance(props.config);
     DomBuilder.getInstance(props.rootSelector);

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,6 @@ import { ChatWrapper } from './components/chat-item/chat-wrapper';
 import { FeedbackForm } from './components/feedback-form/feedback-form';
 import { MynahUITabsStore } from './helper/tabs-store';
 import { Config } from './helper/config';
-import { marked } from 'marked';
 import './styles/styles.scss';
 import { generateUID } from './helper/guid';
 import { NoTabs } from './components/no-tabs';
@@ -205,13 +204,6 @@ export class MynahUI {
   private readonly chatWrappers: Record<string, ChatWrapper> = {};
 
   constructor (props: MynahUIProps) {
-    // Fixes for marked
-    marked.use({
-      renderer: {
-        listitem: (src) => `<li>${marked.parse(src)}</li>`
-      },
-    });
-
     this.props = props;
     Config.getInstance(props.config);
     DomBuilder.getInstance(props.rootSelector);

--- a/src/styles/_animations.scss
+++ b/src/styles/_animations.scss
@@ -24,20 +24,13 @@
 
 @keyframes typewriter {
     0% {
-        visibility: hidden;
-        opacity: 0;
-    }
-    1% {
         visibility: visible;
         opacity: 0;
+        max-height: 1px;
     }
     100% {
         opacity: 1;
-        visibility: visible;
-    }
-}
-@keyframes typewriter-visibility-only {
-    to {
+        max-height: 10000vh;
         visibility: visible;
     }
 }

--- a/src/styles/components/card/_card-body.scss
+++ b/src/styles/components/card/_card-body.scss
@@ -149,6 +149,12 @@
       box-sizing: border-box;
     }
 
+    > blockquote > p:last-of-type{
+      margin-block-end: 0;
+    }
+    > blockquote > p:first-of-type{
+      margin-block-start: 0;
+    }
     > p:last-of-type {
       margin-block-end: 0;
     }


### PR DESCRIPTION
This PR mainly contains `marked` markdown parser and typewriter animation improvements.

## Problem
- In some edge cases, inside markdown list items, some parts of the typewriter animation wrappers are visible inside code blocks. 
- `blockquote`s have too much padding from top if the first item is `p` and from bottom if the last item is `p`.

## Solution
- To improve markdown parser stability and performance, `marked` dependency is updated to its latest major version.
  - New `marked` update has two return types, `string | Promise<string>`. We're not using asyn parser structure, because of that we had to cast all `marked` usages to `string`.
- To avoid unwanted typewriter animations,  typewriter animator wrapper extension of `marked` is moved to render process of `card-body` component instead of setting it globally with `marked.use`. Now, we're only adding typewriter animations to card bodies only during parsing the message body. 
- In addition to those, for list items inside markdown, a check is added to skip typewriter animation wrapper addition if the text part (word) is at the start, in the middle or at the end of a code field. 
  - Unfortunately, the fix added for `listitems` renderer doesn't render code items __(block or inline)__ in the same order with the main parser. It parses the code fields after the text items unlike the main parser. Which means that when we're parsing `listitem`s, text parts can still contain \` (back ticks). We're avoiding it by checking if the word is inside a code field or not. If the \` check mathes with an escaped one, it is not a problem since it will still show up but without animating. (Check example app.)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
