### PR TITLE
Several Bug fixes and feature additions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,7 +9,8 @@ postinstall.js
 **/jest.config.js
 **/webpack.config.js
 dist/**
-example/**
+example*/**
+*api-docs/**
 docs/**
 out/**
 *.config.js

--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -576,6 +576,7 @@ interface ChatItem {
   body?: string; // supports MARKDOWN string
   customRenderer?: string | ChatItemBodyRenderer | ChatItemBodyRenderer[];
   messageId?: string;
+  snapToTop?: boolean;
   canBeVoted?: boolean; // requires messageId to be filled to show vote thumbs
   codeInsertToCursorEnabled?: boolean; // show or hide copy buttons on all code blocks for this message
   codeCopyToClipboardEnabled?: boolean; // show or hide insert to cursor buttons on all code blocks for this message
@@ -1165,6 +1166,30 @@ Even though we don't want you to write styles for the components, you might have
 
 
 That's all!, please also see the **[samples data](https://github.com/aws/mynah-ui/blob/6dd5cfbbb9e9d67fec19c40a2f9fbd7dba4c027c/example/src/samples/sample-data.ts#L544)** of both options we've used in the example app.
+
+---
+
+## `snapToTop`
+It gives you the option to snap the card to the top of the scrolling container. By default, if the user already scrolled to the bottom of the container, container will autoscroll whenever the content is updated. 
+
+**BUT:** There is one thing you need to think about, if your card is a streaming one, you may want to give the `snapToTop` value with the last stream part, otherwise after each content update it will snap to top which may cause a flickery view. And also it would be nice to show the content while it is being generated, and when it ends let it snap to top. **If** your chat item type is a strait `ANSWER`, you should give it initially with the data, when it appears on the screen it will be already snapped to top.
+
+```typescript
+const mynahUI = new MynahUI({
+    tabs: {
+        'tab-1': {
+            ...
+        }
+    }
+});
+
+mynahUI.addChatItem('tab-1', {
+    type: ChatItemType.ANSWER,
+    ...
+    snapToTop: true,
+    body: "Put a very long message to see if it really snaps or still scrolls."
+});
+```
 
 ---
 

--- a/example/src/commands.ts
+++ b/example/src/commands.ts
@@ -6,6 +6,7 @@ export enum Commands {
     STATUS_CARDS = '/cards-with-status-colors',
     FORM_CARD = '/card-with-a-form',
     CARD_WITH_MARKDOWN_LIST = '/card-with-markdown-list',
+    CARD_SNAPS_TO_TOP = '/card-snaps-to-top',
     FILE_LIST_CARD = '/card-with-a-file-list',
     PROGRESSIVE_CARD = '/card-with-progressing-content',
     IMAGE_IN_CARD = '/card-with-image-inside',

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -54,6 +54,10 @@ export const QuickActionCommands:QuickActionCommandGroup[] = [
         description: 'ChatItem card with a complex markdown list inside.',
       },
       {
+        command: Commands.CARD_SNAPS_TO_TOP,
+        description: 'ChatItem card which snaps to top of the scolling container after the stream finishes or when the snapToTop value is set to true.',
+      },
+      {
         command: Commands.PROGRESSIVE_CARD,
         description: 'ChatItem cards can show a progress with its content. It doesn\'t have to be a stream by appending text each time.',
       },

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -279,6 +279,9 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
         case Commands.CARD_WITH_MARKDOWN_LIST:
           getGenerativeAIAnswer(tabId, sampleMarkdownList);
           break;
+        case Commands.CARD_SNAPS_TO_TOP:
+          getGenerativeAIAnswer(tabId, [...sampleMarkdownList.slice(0,-1), {body: sampleMarkdownList.slice(-1)[0].body, snapToTop: true}]);
+          break;
         case Commands.PROGRESSIVE_CARD:
           getGenerativeAIAnswer(tabId, exampleProgressCards);
           break;

--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -14,6 +14,7 @@ import sampleList0 from './sample-list-0.md';
 import sampleList1 from './sample-list-1.md';
 import sampleList2 from './sample-list-2.md';
 import sampleList3 from './sample-list-3.md';
+import sampleList4 from './sample-list-4.md';
 import SampleCode from './sample-code.md';
 import { Commands } from '../commands';
 
@@ -63,6 +64,7 @@ export const sampleMarkdownList: Partial<ChatItem>[] = [
   { body: `${sampleList1 as string}`},
   { body: `${sampleList2 as string}`},
   { body: `${sampleList3 as string}`},
+  { body: `${sampleList4 as string}`},
 ];
 
 export const exampleStreamParts: Partial<ChatItem>[] = [

--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -155,6 +155,10 @@ export const defaultFollowUps: ChatItem = {
         pillText: 'Markdown list',
       },
       {
+        command: Commands.CARD_SNAPS_TO_TOP,
+        pillText: 'Snaps to top',
+      },
+      {
         command: Commands.FILE_LIST_CARD,
         pillText: 'File list',
       },

--- a/example/src/samples/sample-list-4.md
+++ b/example/src/samples/sample-list-4.md
@@ -26,3 +26,14 @@ Nested List with numbers.
 2. **Item2** This is the second list item.
 3. **Item3** This is the third list item.
 4. **Item4** This is the fourth list item. And it also has a [LINK](#) inside.
+
+To create a code **block** in Markdown, you would use the triple backticks (\`\`\`) with following syntax:
+
+> \`\`\`
+> let a = 5;
+> console.log(a);
+> a = a + 5;
+> console.log(a);
+> \`\`\`
+
+The asterisk `*` creates an unordered list item, and the double asterisks `**text**` wrap the text you want to make bold. [[1]](https://aasiyaonize.hashnode.dev/markdown-and-restructured)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.8.1",
+      "version": "4.9.0",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/components/card/card-body.ts
+++ b/src/components/card/card-body.ts
@@ -109,6 +109,11 @@ export class CardBody {
                 this.props.onLinkClick(url, e);
               }
             },
+            auxclick: (e: MouseEvent) => {
+              if (this.props.onLinkClick !== undefined) {
+                this.props.onLinkClick(url, e);
+              }
+            },
           },
           attributes: { href: elementFromNode.getAttribute('href') ?? '', target: '_blank' },
           innerHTML: elementFromNode.innerHTML,

--- a/src/components/chat-item/chat-item-card.ts
+++ b/src/components/chat-item/chat-item-card.ts
@@ -19,6 +19,7 @@ import { generateUID } from '../../helper/guid';
 import { ChatItemFormItemsWrapper } from './chat-item-form-items';
 import { ChatItemButtonsWrapper } from './chat-item-buttons';
 import { cleanHtml } from '../../helper/sanitize';
+import { CONTAINER_GAP } from './chat-wrapper';
 
 const TYPEWRITER_STACK_TIME = 500;
 export interface ChatItemCardProps {
@@ -89,6 +90,7 @@ export class ChatItemCard {
     setTimeout(
       () => {
         generatedCard.addClass('reveal');
+        this.checkCardSnap();
       },
       this.props.chatItem.type === ChatItemType.PROMPT ? 10 : 200
     );
@@ -372,7 +374,15 @@ export class ChatItemCard {
         `,
     });
 
+  private readonly checkCardSnap = (): void => {
+    // If the chat item has snapToTop value as true, we'll snap the card to the container top
+    if (this.render.offsetParent != null && this.props.chatItem.snapToTop === true) {
+      this.render.offsetParent.scrollTop = this.render.offsetTop - CONTAINER_GAP - (this.render.offsetParent as HTMLElement).offsetTop;
+    }
+  };
+
   public readonly updateCard = (): void => {
+    this.checkCardSnap();
     if (this.updateTimer === undefined && this.updateStack.length > 0) {
       const updateWith: Partial<ChatItem> | undefined = this.updateStack.shift();
       if (updateWith !== undefined) {

--- a/src/components/chat-item/chat-item-followup.ts
+++ b/src/components/chat-item/chat-item-followup.ts
@@ -63,16 +63,23 @@ export class ChatItemFollowUpContainer {
     Array.from(this.render.getElementsByTagName('a')).forEach(a => {
       const url = a.href;
 
-      a.onclick = (event?: MouseEvent) => {
-        MynahUIGlobalEvents
-          .getInstance()
-          .dispatch(MynahEventNames.LINK_CLICK, {
-            tabId: this.props.tabId,
-            messageId: this.props.chatItem.messageId,
-            link: url,
-            event,
-          });
+      a.onclick = (event: MouseEvent) => {
+        this.handleLinkClick(url, event);
+      };
+      a.onauxclick = (event: MouseEvent) => {
+        this.handleLinkClick(url, event);
       };
     });
   }
+
+  private readonly handleLinkClick = (url: string, event?: MouseEvent): void => {
+    MynahUIGlobalEvents
+      .getInstance()
+      .dispatch(MynahEventNames.LINK_CLICK, {
+        tabId: this.props.tabId,
+        messageId: this.props.chatItem.messageId,
+        link: url,
+        event,
+      });
+  };
 }

--- a/src/components/chat-item/chat-wrapper.ts
+++ b/src/components/chat-item/chat-wrapper.ts
@@ -15,6 +15,7 @@ import { ChatPromptInput } from './chat-prompt-input';
 import { ChatPromptInputInfo } from './chat-prompt-input-info';
 import { ChatPromptInputStickyCard } from './chat-prompt-input-sticky-card';
 
+export const CONTAINER_GAP = 12;
 export interface ChatWrapperProps {
   onStopChatResponse?: (tabId: string) => void;
   tabId: string;

--- a/src/components/chat-item/prompt-input/prompt-text-input.ts
+++ b/src/components/chat-item/prompt-input/prompt-text-input.ts
@@ -37,7 +37,7 @@ export class PromptTextInput {
         ...(initialDisabledState ? { disabled: 'disabled' } : {}),
         tabindex: '1',
         rows: '1',
-        maxlength: MAX_USER_INPUT.toString(),
+        maxlength: MAX_USER_INPUT().toString(),
         type: 'text',
         placeholder: MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).getValue('promptInputPlaceholder'),
         value: '',

--- a/src/components/source-link/source-link-header.ts
+++ b/src/components/source-link/source-link-header.ts
@@ -59,6 +59,7 @@ export class SourceLinkHeader {
               events: {
                 ...(props.onClick !== undefined && {
                   click: props.onClick,
+                  auxclick: props.onClick,
                 }),
               },
               attributes: { href: props.sourceLink.url, target: '_blank' },
@@ -74,6 +75,7 @@ export class SourceLinkHeader {
               events: {
                 ...(props.onClick !== undefined && {
                   click: props.onClick,
+                  auxclick: props.onClick
                 }),
               },
               attributes: { href: props.sourceLink.url, target: '_blank' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -208,7 +208,7 @@ export class MynahUI {
     // Apply global fix for marked listitem content is not getting parsed.
     marked.use({
       renderer: {
-        listitem: (src) => `<li>${marked.parse(src, { breaks: true }) as string}</li>`
+        listitem: (src) => `<li>${marked.parse(src, { breaks: false }) as string}</li>`
       },
     });
 

--- a/src/static.ts
+++ b/src/static.ts
@@ -170,6 +170,7 @@ export interface ChatItem {
   body?: string;
   customRenderer?: string | ChatItemBodyRenderer | ChatItemBodyRenderer[];
   messageId?: string;
+  snapToTop?: boolean;
   canBeVoted?: boolean;
   codeInsertToCursorEnabled?: boolean;
   codeCopyToClipboardEnabled?: boolean;

--- a/src/styles/components/chat/_chat-items-container.scss
+++ b/src/styles/components/chat/_chat-items-container.scss
@@ -1,4 +1,5 @@
 > .mynah-chat-items-container {
+    position: relative;
     display: flex;
     flex: 1 1 0%;
     overflow-x: hidden;

--- a/src/styles/components/chat/_chat-overflowing-intermediate-block.scss
+++ b/src/styles/components/chat/_chat-overflowing-intermediate-block.scss
@@ -27,8 +27,10 @@
     min-height: var(--mynah-sizing-8);
     padding-left: var(--mynah-sizing-2);
     border: var(--mynah-button-border-width) solid currentColor;
+    background-color: var(--mynah-card-bg);
     &:not(:hover) {
-      opacity: 0.5;
+      opacity: 0.9;
+      filter: brightness(0.95);
     }
     &:active {
       box-shadow: none;


### PR DESCRIPTION
## Problem
- Inside chat body, if there is a code block inside a list item it shows `<br/>` tags
- Prompt input field in Q Chat tabs doesn't stop after it reaches to the given maxUserInput
- Links in JetBrains inside Q Panel opens in Q panel's own window with middle mouse click.
- Card auto scrolling should be optional

## Solution
- Removed break generation for list items (which is the supposed way from markedjs and github's own markdown styling)
- Prompt input `maxLength` value was set incorrectly, it was using the function declaration instead of function call.
- As we do for the clicks, we also mapped the middle clicks (`auxclick`) to the same handler functions, which will allow the JB side to control the event behavior (preventDefault) as they were doing for the normal clicks to avoid links opening inside Q panel.
- A new option is added for the ChatItem which is called `snapToTop` for snap the card to the top of the scrolling container when the value is true (initially or during a stream)


## Other
- Bumped the version to `v4.9.0`
- Add `snapToTop` documentation to the `DATAMODEL.md`
- Updated eslint ignore list to avoid api-docs folder and future example folders checked for a linting issues.
- Updated example app with a more complex markdown list example and `snapToTop` option showcase.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
