### PR TITLE
Dogusata/add check statement to clipboard access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.10.0",
+      "version": "4.10.1",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/components/syntax-highlighter.ts
+++ b/src/components/syntax-highlighter.ts
@@ -252,35 +252,31 @@ export class SyntaxHighlighter {
     type: 'block'
   });
 
-  private readonly copyToClipboard = (
+  private readonly copyToClipboard = async (
     textToSendClipboard: string,
     type?: CodeSelectionType,
     notificationText?: string,
-  ): void => {
+  ): Promise<void> => {
     if (!document.hasFocus()) {
       window.focus();
     }
-    navigator.clipboard
-      .writeText(textToSendClipboard)
-      .then(() => {
-        if (this.props?.onCopiedToClipboard !== undefined) {
-          this.props?.onCopiedToClipboard(
-            type,
-            textToSendClipboard,
-            this.props.index
-          );
-        }
-        if (notificationText !== undefined) {
-          // eslint-disable no-new
-          new Notification({
-            content: notificationText,
-            title: Config.getInstance().config.texts.copyToClipboard,
-            duration: 2000,
-          }).notify();
-        }
-      })
-      .catch(e => {
-        //
-      });
+    try {
+      await navigator.clipboard.writeText(textToSendClipboard);
+    } finally {
+      if (this.props?.onCopiedToClipboard != null) {
+        this.props?.onCopiedToClipboard(
+          type,
+          textToSendClipboard,
+          this.props.index
+        );
+      }
+      if (notificationText != null) {
+        new Notification({
+          content: notificationText,
+          title: Config.getInstance().config.texts.copyToClipboard,
+          duration: 2000,
+        }).notify();
+      }
+    }
   };
 }


### PR DESCRIPTION
## Problem
If clipboard is not available, webviews throwing an error and blocks the rest of the usage when user hits copy button on code blocks.

## Solution
Clipboard access is wrapped with a try/finally statement. Even though we don't have access to clipboard, we're still throwing internal event to make the text copy operation handled by the consumer.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
