### PR TITLE
Dogusata/add code diff to syntax highlighter and file description tooltip

### DIFF
--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -536,6 +536,7 @@ export interface TreeNodeDetails {
   status?: 'info' | 'success' | 'warning' | 'error';
   icon?: MynahIcons;
   label?: string;
+  description?: string; // Markdown tooltip
 }
 
 export interface SourceLink {
@@ -1348,7 +1349,8 @@ mynahUI.addChatItem(tabId, {
       'src/devfile.yaml': {
         status: 'error',
         label: "Change rejected",
-        icon: MynahIcons.REVERT
+        icon: MynahIcons.REVERT,
+        description: 'Markdown tooltip to show'
       }
     }
   },

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -27,6 +27,7 @@ import {
   exampleRichFollowups,
   exampleStreamParts,
   sampleMarkdownList,
+  exampleCodeDiff,
 } from './samples/sample-data';
 import escapeHTML from 'escape-html';
 import './styles/styles.scss';
@@ -54,18 +55,13 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
           icon: MynahIcons.ELLIPSIS,
           items: [
             {
-              id: 'menu-action-1',
-              text: 'Menu action 1!',
-              icon: MynahIcons.CHAT,
-            },
-            {
-              id: 'menu-action-2',
-              text: 'Menu action 2!',
-              icon: MynahIcons.COMMENT,
+              id: 'show-code-diff',
+              text: 'Show code diff!',
+              icon: MynahIcons.CODE_BLOCK,
             },
             {
               id: 'insert-code',
-              icon: MynahIcons.CODE_BLOCK,
+              icon: MynahIcons.CURSOR_INSERT,
               text: 'Insert code!',
             },
           ],
@@ -86,6 +82,11 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
       if (buttonId === 'clear') {
         mynahUI.updateStore(tabId, {
           chatItems: [],
+        });
+      } else if (buttonId === 'show-code-diff') {
+        mynahUI.addChatItem(tabId, {
+          type: ChatItemType.ANSWER,
+          body: exampleCodeDiff
         });
       } else if (buttonId === 'insert-code') {
         mynahUI.addToUserPrompt(tabId, exampleCodeBlockToInsert, 'code');

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -198,6 +198,11 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
         case 'reject-change':
           mynahUI.updateChatAnswerWithMessageId(tabId, messageId, exampleFileListChatItemForUpdate);
           break;
+        case 'show-diff':
+          mynahUI.updateChatAnswerWithMessageId(tabId, messageId, {
+            body: exampleCodeDiff
+          });
+          break;
         case 'revert-rejection':
           mynahUI.updateChatAnswerWithMessageId(tabId, messageId, {fileList: exampleFileListChatItem.fileList});
           break;

--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -16,6 +16,7 @@ import sampleList2 from './sample-list-2.md';
 import sampleList3 from './sample-list-3.md';
 import sampleList4 from './sample-list-4.md';
 import SampleCode from './sample-code.md';
+import SampleDiff from './sample-diff.md';
 import { Commands } from '../commands';
 
 export const mynahUIQRImageBase64 =
@@ -104,6 +105,7 @@ export const exampleStreamParts: Partial<ChatItem>[] = [
 ];
 
 export const exampleCodeBlockToInsert = SampleCode;
+export const exampleCodeDiff = SampleDiff;
 
 export const exampleRichFollowups: ChatItem = {
     type: ChatItemType.SYSTEM_PROMPT,
@@ -201,6 +203,11 @@ export const exampleFileListChatItem: ChatItem = {
                 },
             ],
         },
+        details: {
+            'src/index.ts': {
+                description: exampleCodeDiff
+            },
+        },
     },
 };
 
@@ -214,7 +221,7 @@ export const exampleFileListChatItemForUpdate: Partial<ChatItem> = {
             'src/index.ts': {
                 status: 'error',
                 label: 'File rejected',
-                icon: MynahIcons.CANCEL_CIRCLE,
+                icon: MynahIcons.CANCEL_CIRCLE
             },
         },
         actions: {

--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -201,6 +201,11 @@ export const exampleFileListChatItem: ChatItem = {
                     name: 'reject-change',
                     description: 'Reject Change',
                 },
+                {
+                    icon: MynahIcons.CODE_BLOCK,
+                    name: 'show-diff',
+                    description: 'Show Diff',
+                },
             ],
         },
         details: {

--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -221,7 +221,8 @@ export const exampleFileListChatItemForUpdate: Partial<ChatItem> = {
             'src/index.ts': {
                 status: 'error',
                 label: 'File rejected',
-                icon: MynahIcons.CANCEL_CIRCLE
+                icon: MynahIcons.CANCEL_CIRCLE,
+                description: exampleCodeDiff
             },
         },
         actions: {

--- a/example/src/samples/sample-diff.md
+++ b/example/src/samples/sample-diff.md
@@ -1,0 +1,34 @@
+### Changes on `index.ts`
+
+ 
+> _Between line 42 and 70_
+```diff-typescript
+const mynahUI = new MynahUI({
+    tabs: {
+        'tab-1': {
+            isSelected: true,
+            store: {
+                tabTitle: 'Chat',
+                chatItems: [
+                    {
+                        type: ChatItemType.ANSWER,
+                        body: 'Welcome to our chat!',
+                        messageId: 'welcome-message'
+                    },
+                ],
+-                promptInputPlaceholder: 'Write your question',
++                promptInputPlaceholder: 'Type your question',
+            }
+        }
+    },
+-    onChatPrompt: () => {},
++    onChatPrompt: (tabId: string, prompt: ChatPrompt) => {
++        mynahUI.addChatItem(tabId, {
++            type: ChatItemType.PROMPT,
++            messageId: new Date().getTime().toString(),
++            body: prompt.escapedPrompt
++        });
++        // call your genAI action
++    }
+});
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.10.1",
+  "version": "4.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.10.1",
+      "version": "4.11.0",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.10.1",
+  "version": "4.11.0",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/components/chat-item/chat-item-tree-file.ts
+++ b/src/components/chat-item/chat-item-tree-file.ts
@@ -116,7 +116,7 @@ export class ChatItemTreeFile {
   }
 
   private readonly showTooltip = (content: string, vDir?: OverlayVerticalDirection, hDir?: OverlayHorizontalDirection): void => {
-    if (content.trim() !== undefined) {
+    if (content.trim() !== '') {
       clearTimeout(this.fileTooltipTimeout);
       this.fileTooltipTimeout = setTimeout(() => {
         this.fileTooltip = new Overlay({
@@ -143,8 +143,10 @@ export class ChatItemTreeFile {
   };
 
   public readonly hideTooltip = (): void => {
-    clearTimeout(this.fileTooltipTimeout);
-    if (this.fileTooltip !== null) {
+    if (this.fileTooltipTimeout != null) {
+      clearTimeout(this.fileTooltipTimeout);
+    }
+    if (this.fileTooltip != null) {
       this.fileTooltip?.close();
       this.fileTooltip = null;
     }

--- a/src/components/chat-item/chat-item-tree-file.ts
+++ b/src/components/chat-item/chat-item-tree-file.ts
@@ -19,7 +19,7 @@ export interface ChatItemTreeFileProps {
   actions?: FileNodeAction[];
 }
 
-const PREVIEW_DELAY = 350;
+const PREVIEW_DELAY = 250;
 export class ChatItemTreeFile {
   render: ExtendedHTMLElement;
   private fileTooltip: Overlay | null;

--- a/src/components/chat-item/chat-item-tree-file.ts
+++ b/src/components/chat-item/chat-item-tree-file.ts
@@ -146,9 +146,7 @@ export class ChatItemTreeFile {
     if (this.fileTooltipTimeout != null) {
       clearTimeout(this.fileTooltipTimeout);
     }
-    if (this.fileTooltip != null) {
-      this.fileTooltip?.close();
-      this.fileTooltip = null;
-    }
+    this.fileTooltip?.close();
+    this.fileTooltip = null;
   };
 }

--- a/src/components/overlay.ts
+++ b/src/components/overlay.ts
@@ -131,65 +131,29 @@ export class Overlay {
       'beforeend'
     );
 
-    const containerRectangle = this.container.getBoundingClientRect();
+    // Screen edge fixes
     const winHeight = Math.max(document.documentElement.clientHeight ?? 0, window.innerHeight ?? 0);
     const winWidth = Math.max(document.documentElement.clientWidth ?? 0, window.innerWidth ?? 0);
+    const lastContainerRect = this.container.getBoundingClientRect();
+    const effectiveTop = parseFloat(this.container.style.top ?? '0');
+    const effectiveLeft = parseFloat(this.container.style.left ?? '0');
 
-    // if it will open at the center of the reference element or point
-    // we only need the half of both measurements
-    const comparingWidth =
-            horizontalDirection === OverlayHorizontalDirection.CENTER
-              ? containerRectangle.width / 2
-              : containerRectangle.width;
-    const comparingHeight =
-            verticalDirection === OverlayVerticalDirection.CENTER
-              ? containerRectangle.height / 2
-              : containerRectangle.height;
-
-    // if overlay will open to right or at center
-    // we're checking if it exceeds from the right edge of the window
-    if (
-      horizontalDirection !== OverlayHorizontalDirection.TO_LEFT &&
-            horizontalDirection !== OverlayHorizontalDirection.END_TO_LEFT &&
-            comparingWidth + OVERLAY_MARGIN + calculatedLeft > winWidth
-    ) {
-      if (horizontalDirection === OverlayHorizontalDirection.CENTER) {
-        // Exceed right edge of the window, shift left by the width of exceeding part * 0.5
-        // to correctly handle the 50% horizontal transform
-        this.container.style.left =
-                  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-                  (calculatedLeft - (containerRectangle.width + (OVERLAY_MARGIN * 2) + calculatedLeft - winWidth) * 0.5) + 'px';
-      } else {
-        this.container.style.left =
-                  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-                  calculatedLeft - (containerRectangle.width + OVERLAY_MARGIN + calculatedLeft - winWidth) + 'px';
-      }
-    }
-    // else if the direction is selected as a one that goes to the left,
-    // we need to check if it is exceeding from the left edge of the window
-    else if (calculatedLeft + comparingWidth - containerRectangle.width < OVERLAY_MARGIN) {
-      this.container.style.left =
-                // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-                calculatedLeft + (OVERLAY_MARGIN - calculatedLeft + (comparingWidth - containerRectangle.width)) + 'px';
+    // Vertical edge
+    // Check top exceeding
+    if (lastContainerRect.top < OVERLAY_MARGIN) {
+      this.container.style.top = `${effectiveTop + (OVERLAY_MARGIN - lastContainerRect.top)}px`;
+    } // Check bottom exceeding
+    else if (lastContainerRect.top + lastContainerRect.height + OVERLAY_MARGIN > winHeight) {
+      this.container.style.top = `${effectiveTop - (lastContainerRect.top + lastContainerRect.height + OVERLAY_MARGIN - winHeight)}px`;
     }
 
-    // if overlay will open to bottom or at center
-    // we're checking if it exceeds from the bottom edge of the window
-    if (
-      verticalDirection !== OverlayVerticalDirection.TO_TOP &&
-            verticalDirection !== OverlayVerticalDirection.END_TO_TOP &&
-            comparingHeight + OVERLAY_MARGIN + calculatedTop > winHeight
-    ) {
-      this.container.style.top =
-                // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-                calculatedTop - (comparingHeight + OVERLAY_MARGIN + calculatedTop - winHeight) + 'px';
-    }
-    // else if the direction is selected as a one that goes to the top,
-    // we need to check if it is exceeding from the top edge of the window
-    else if (calculatedTop + comparingHeight - containerRectangle.height < OVERLAY_MARGIN) {
-      this.container.style.top =
-                // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-                calculatedTop + (OVERLAY_MARGIN - calculatedTop + (comparingHeight - containerRectangle.height)) + 'px';
+    // Horizontal edge
+    // Check left exceeding
+    if (lastContainerRect.left < OVERLAY_MARGIN) {
+      this.container.style.left = `${effectiveLeft + (OVERLAY_MARGIN - lastContainerRect.left)}px`;
+    } // Check right exceeding
+    else if (lastContainerRect.left + lastContainerRect.width + OVERLAY_MARGIN > winWidth) {
+      this.container.style.left = `${effectiveLeft - (lastContainerRect.left + lastContainerRect.width + OVERLAY_MARGIN - winWidth)}px`;
     }
 
     // we need to delay the class toggle

--- a/src/components/syntax-highlighter.ts
+++ b/src/components/syntax-highlighter.ts
@@ -13,6 +13,7 @@ import 'prismjs/components/prism-clike.min';
 import 'prismjs/components/prism-javascript.min';
 import 'prismjs/components/prism-typescript.min';
 import 'prismjs/components/prism-jsx.min';
+import 'prismjs/components/prism-diff.min';
 import 'prismjs/components/prism-tsx.min';
 import 'prismjs/components/prism-lua.min';
 import 'prismjs/components/prism-java.min';
@@ -28,9 +29,11 @@ import 'prismjs/components/prism-regex.min';
 import 'prismjs/components/prism-scala.min';
 import 'prismjs/components/prism-scss.min';
 import 'prismjs/components/prism-less.min';
-
 import 'prismjs/plugins/line-numbers/prism-line-numbers.js';
 import 'prismjs/plugins/keep-markup/prism-keep-markup.js';
+import 'prismjs/plugins/diff-highlight/prism-diff-highlight.min';
+// import 'prismjs/plugins/diff-highlight/prism-diff-highlight.min.css';
+
 import {
   CodeSelectionType,
 } from '../static';
@@ -48,6 +51,7 @@ const IMPORTED_LANGS = [
   'xml',
   'css',
   'clike',
+  'diff',
   'javascript',
   'typescript',
   'jsx',
@@ -66,6 +70,29 @@ const IMPORTED_LANGS = [
   'scala',
   'scss',
   'less',
+  'diff-markup',
+  'diff-xml',
+  'diff-css',
+  'diff-clike',
+  'diff-diff',
+  'diff-javascript',
+  'diff-typescript',
+  'diff-jsx',
+  'diff-tsx',
+  'diff-lua',
+  'diff-java',
+  'diff-json',
+  'diff-markdown',
+  'diff-mongodb',
+  'diff-c',
+  'diff-bash',
+  'diff-csharp',
+  'diff-objectivec',
+  'diff-python',
+  'diff-regex',
+  'diff-scala',
+  'diff-scss',
+  'diff-less',
 ];
 const DEFAULT_LANG = 'clike';
 
@@ -133,6 +160,7 @@ export class SyntaxHighlighter {
       type: 'pre',
       classNames: [ 'keep-markup',
           `language-${props.language !== undefined && IMPORTED_LANGS.includes(props.language) ? props.language : DEFAULT_LANG}`,
+          ...(((props.language?.match('diff')) != null) ? [ 'diff-highlight' ] : []),
           ...(props.showLineNumbers === true ? [ 'line-numbers' ] : []),
       ],
       children: [

--- a/src/components/syntax-highlighter.ts
+++ b/src/components/syntax-highlighter.ts
@@ -32,7 +32,6 @@ import 'prismjs/components/prism-less.min';
 import 'prismjs/plugins/line-numbers/prism-line-numbers.js';
 import 'prismjs/plugins/keep-markup/prism-keep-markup.js';
 import 'prismjs/plugins/diff-highlight/prism-diff-highlight.min';
-// import 'prismjs/plugins/diff-highlight/prism-diff-highlight.min.css';
 
 import {
   CodeSelectionType,

--- a/src/static.ts
+++ b/src/static.ts
@@ -165,6 +165,7 @@ export interface TreeNodeDetails {
   status?: 'info' | 'success' | 'warning' | 'error';
   icon?: MynahIcons;
   label?: string;
+  description?: string;
 }
 
 export interface ChatItem {

--- a/src/styles/components/_overlay.scss
+++ b/src/styles/components/_overlay.scss
@@ -32,6 +32,8 @@
         border-radius: var(--mynah-card-radius);
         max-width: calc(100vw - var(--mynah-sizing-8))!important;
         width: max-content;
+        height: max-content;
+        max-height: calc(100vh - var(--mynah-sizing-8))!important;
 
         .mynah-card,
         .mynah-card * {

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -1,3 +1,16 @@
+pre.diff-highlight > code .token.deleted:not(.prefix),
+pre > code.diff-highlight .token.deleted:not(.prefix) {
+    background-color: rgba(255, 0, 0, 0.1);
+    color: inherit;
+    display: block;
+}
+pre.diff-highlight > code .token.inserted:not(.prefix),
+pre > code.diff-highlight .token.inserted:not(.prefix) {
+    background-color: rgba(0, 255, 128, 0.1);
+    color: inherit;
+    display: block;
+}
+
 .mynah-syntax-highlighter {
     display: flex;
     flex-flow: column nowrap;
@@ -16,7 +29,7 @@
     color: var(--mynah-color-text-default);
     &:before,
     & > .line-numbers-rows:before {
-        content: "";
+        content: '';
         position: absolute;
         left: 0;
         top: 0;
@@ -40,7 +53,7 @@
         position: relative;
         border-top: 1px solid var(--mynah-color-border-default);
         &:before {
-            content: "";
+            content: '';
             position: absolute;
             left: 0;
             top: 0;
@@ -87,7 +100,7 @@
             padding: 0;
         }
         &:after {
-            content: "";
+            content: '';
             position: absolute;
             box-sizing: border-box;
             top: -1px;
@@ -104,7 +117,7 @@
             height: calc(100% + 2px);
             left: -4px;
             width: calc(100% + 8px);
-            border-radius:  var(--mynah-input-radius);
+            border-radius: var(--mynah-input-radius);
             box-sizing: border-box;
         }
     }
@@ -164,7 +177,7 @@
         .token.number,
         .token.constant,
         .token.symbol,
-        .token.deleted {
+        .token.inserted {
             color: var(--mynah-color-syntax-property);
         }
 
@@ -173,7 +186,7 @@
         .token.string,
         .token.char,
         .token.builtin,
-        .token.inserted {
+        .token.deleted {
             color: var(--mynah-color-syntax-attr);
         }
 
@@ -196,7 +209,7 @@
             color: var(--mynah-color-syntax-function);
             font-weight: 500;
         }
-        
+
         .token.regex,
         .token.important,
         .token.variable {

--- a/src/styles/components/chat/_chat-item-tree-view.scss
+++ b/src/styles/components/chat/_chat-item-tree-view.scss
@@ -88,7 +88,19 @@
       position: relative;
       box-sizing: content-box;
       border-radius: var(--mynah-input-radius);
-
+      &:after{
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: all;
+        z-index: 100;
+      }
+      > .mynah-chat-item-tree-view-file-item-actions {
+        z-index: 150;
+      }
       &:not(:hover) {
         > .mynah-chat-item-tree-view-file-item-actions {
           display: none;


### PR DESCRIPTION
## Problem
- SyntaxHighlighter should support diff view. Since it is already there with `prism.js` it has to be enabled.
- FileItem component should support markdown tooltips
- Sometimes tooltips exceeding the screen edges
## Solution
- Updated SyntaxHighlighter component to support diff view too
- Added tooltip ability to FileItem component
- Fixed tooltip edge bleeding issue.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
