### PR TITLE
Dogusata/hot fix file name starts with dot and slash it doesnt have actions

### DIFF
--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -192,26 +192,41 @@ export const exampleFileListChatItem: ChatItem = {
     type: ChatItemType.ANSWER,
     fileList: {
         rootFolderTitle: 'Changes',
-        filePaths: ['src/index.ts'],
+        filePaths: ['./package.json', './tsconfig.json', 'src/game.ts', 'tests/game.test.ts'],
         deletedFiles: [],
         actions: {
-            'src/index.ts': [
+            './package.json': [
                 {
                     icon: MynahIcons.CANCEL_CIRCLE,
+                    status: 'error',
                     name: 'reject-change',
-                    description: 'Reject Change',
-                },
-                {
-                    icon: MynahIcons.CODE_BLOCK,
-                    name: 'show-diff',
-                    description: 'Show Diff',
+                    description: 'Reject change',
                 },
             ],
-        },
-        details: {
-            'src/index.ts': {
-                description: exampleCodeDiff
-            },
+            './tsconfig.json': [
+                {
+                    icon: MynahIcons.CANCEL_CIRCLE,
+                    status: 'error',
+                    name: 'reject-change',
+                    description: 'Reject change',
+                },
+            ],
+            'src/game.ts': [
+                {
+                    icon: MynahIcons.CANCEL_CIRCLE,
+                    status: 'error',
+                    name: 'reject-change',
+                    description: 'Reject change',
+                },
+            ],
+            'tests/game.test.ts': [
+                {
+                    icon: MynahIcons.CANCEL_CIRCLE,
+                    status: 'error',
+                    name: 'reject-change',
+                    description: 'Reject change',
+                },
+            ],
         },
     },
 };

--- a/example/src/styles/styles.scss
+++ b/example/src/styles/styles.scss
@@ -146,6 +146,7 @@ body {
     flex-flow: column nowrap;
     justify-content: center;
     align-items: stretch;
+    z-index: 100;
 
     > #amzn-mynah-website-wrapper {
       max-width: var(--mynah-max-width);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.11.0",
+      "version": "4.11.1",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/helper/file-tree.ts
+++ b/src/helper/file-tree.ts
@@ -59,7 +59,7 @@ export const fileListToTree = (
   details?: Record<string, TreeNodeDetails>,
   rootTitle?: string): TreeNode => {
   return [ ...splitFilePaths(modifiedFilePaths, false), ...splitFilePaths(deletedFilePaths, true) ].reduce<TreeNode>(
-    (acc, { filePath, deleted }) => {
+    (acc, { originalFilePath, filePath, deleted }) => {
       // pointer to keep track of the current tree node
       let currentNode = acc;
       for (let i = 0; i < filePath.length; i++) {
@@ -74,8 +74,8 @@ export const fileListToTree = (
             name: fileOrFolder,
             filePath: filePathJoined,
             deleted,
-            actions: actions !== undefined ? actions[filePathJoined] : undefined,
-            details: details !== undefined ? details[filePathJoined] : undefined,
+            actions: actions !== undefined ? actions[originalFilePath] : undefined,
+            details: details !== undefined ? details[originalFilePath] : undefined,
           });
           break;
         } else {
@@ -97,7 +97,7 @@ export const fileListToTree = (
   );
 };
 
-const splitFilePaths = (paths: string[], deleted: boolean): Array<{ filePath: string[]; deleted: boolean }> =>
+const splitFilePaths = (paths: string[], deleted: boolean): Array<{ originalFilePath: string; filePath: string[]; deleted: boolean }> =>
   paths
     // split file path by folder. ignore dot folders
-    .map(filePath => ({ filePath: filePath.split('/').filter(item => item !== undefined && item !== '.'), deleted }));
+    .map(filePath => ({ originalFilePath: filePath, filePath: filePath.split('/').filter(item => item !== undefined && item !== '.'), deleted }));

--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -200,6 +200,11 @@
         align-items: center;
         user-select: none;
         line-height: var(--mynah-line-height);
+        > span {
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow: hidden;
+        }
         * {
             pointer-events: none;
         }

--- a/src/styles/components/chat/_chat-item-tree-view.scss
+++ b/src/styles/components/chat/_chat-item-tree-view.scss
@@ -103,7 +103,8 @@
       }
       &:not(:hover) {
         > .mynah-chat-item-tree-view-file-item-actions {
-          display: none;
+          opacity: 0;
+          pointer-events: none;
         }
       }
 
@@ -179,7 +180,7 @@
         font-size: 90%;
         z-index: 10;
         flex: 1;
-        flex-shrink: 1;
+        flex-shrink: 2;
         overflow: hidden;
 
         > .mynah-chat-item-tree-view-file-item-details-text {
@@ -199,7 +200,7 @@
         font-size: 90%;
         z-index: 10;
         padding-right: var(--mynah-sizing-1);
-
+        flex-shrink: 0;
         > .mynah-button {
           width: auto;
           height: auto;
@@ -236,12 +237,13 @@
         max-width: 100%;
         overflow: hidden;
         z-index: 10;
-        flex-shrink: 1;
+        flex-shrink: 0;
 
         > span {
           text-overflow: ellipsis;
           overflow: hidden;
           white-space: nowrap;
+          max-width: 100%;
         }
       }
 


### PR DESCRIPTION
## Problem
- When the given path for a file starts with `./` it doesn't show the file actions and not triggering the file click.
- When there is a long text inside a followup, it should fit until the line ends instead of cropping at fixed 40 chars.
## Solution
- File path actions and onFileClick events are fixed with original file path check instead of the modified one.
- Added followup inner span text overflow structure instead of cropping the text programmatically and added the check for width overflowing to show the tooltip.


This PR also includes:
- File list updates on the example app
- Z-Index fix for letting the Overlay items show properly

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
