### PR TITLE
chore: add vscode for debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Mynah UI (watch)",
+            "type": "node",
+            "request": "launch",
+            "cwd": "${workspaceRoot}",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run-script", "watch"
+            ],
+            "console": "integratedTerminal",
+        }
+    ]
+  }
+  


### PR DESCRIPTION
Add launch config to run mynah ui inside vscode with debug mode

<img width="1511" alt="Screenshot 2024-06-21 at 11 24 26 AM" src="https://github.com/aws/mynah-ui/assets/371007/12cb095c-71e6-45cd-afad-0bfffb36f3e2">


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
