### PR TITLE
Dogusata/prompt input html escape fix

### DIFF
--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -11,6 +11,7 @@ export interface MynahUIProps {
     messageId: string,
     eventId?: string) => void;
   onReady?: () => void;
+  onFocusStateChanged?: (focusState: boolean) => void;
   onVote?: (
     tabId: string,
     messageId: string,
@@ -293,6 +294,20 @@ This event will be fired when the UI is initialized and rendered without any arg
 ...
 onReady: () => {
       console.log('UI is ready');
+    };
+...
+```
+
+---
+
+### `onFocusStateChanged`
+
+This event will be fired whenever user targets to MynahUI or wents away.
+
+```typescript
+...
+onFocusStateChanged: (focusState: boolean) => {
+      console.log(`MynahUI is ${focusState ? 'focused' : 'not focused'}.`);
     };
 ...
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.14.1",
+      "version": "4.14.2",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/components/chat-item/prompt-input/prompt-text-input.ts
+++ b/src/components/chat-item/prompt-input/prompt-text-input.ts
@@ -1,3 +1,4 @@
+import escapeHTML from 'escape-html';
 import { Config } from '../../../helper/config';
 import { DomBuilder, ExtendedHTMLElement } from '../../../helper/dom';
 import { MynahUIGlobalEvents } from '../../../helper/events';
@@ -133,7 +134,7 @@ export class PromptTextInput {
     if (this.props.contextReplacement === true) {
       newVal = `${newVal.replace(/@\S*/gi, (match) => `<span class="context">${match}</span>`)}&nbsp`;
     }
-    this.promptTextInputSizer.innerHTML = newVal; ;
+    this.promptTextInputSizer.innerHTML = escapeHTML(newVal);
   };
 
   public readonly setContextReplacement = (contextReplacement: boolean): void => {


### PR DESCRIPTION
## Problem
- When user types html special characters inside prompt input, rest of the input text disappears not shown. 
![bug](https://github.com/aws/mynah-ui/assets/116281103/77b1ebe3-27e2-4d8f-863c-6b28fa28d677)


## Solution
- Added html escape to prompt input visualizer.
![fix](https://github.com/aws/mynah-ui/assets/116281103/db9fe5d3-2344-4ca0-be1f-9b50a16e3786)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
