### PR TITLE
Use text-input-color instead of white in mynah-chat-prompt-input color

### DIFF
--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -61,7 +61,7 @@
                     resize: none;
                     background-color: rgba(0, 0, 0, 0);
                     font-size: var(--mynah-font-size-large);
-                    color: rgba(0, 0, 0, 0);
+                    color: var(--mynah-color-text-input);
                     caret-color: var(--mynah-color-text-input);
                     outline: none;
                     width: 100%;


### PR DESCRIPTION
## Problem
Overflown text used to become invisible when you had a large multiline text. Scrolling up and down in the prompt input field also made this issue more apparent

## Solution
`mynah-chat-prompt-input` color was set as white but it should have been using the text input variable color

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
