### PR TITLE
fixed paragraphs being converted to code blocks for user inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.15.1",
+      "version": "4.15.2",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -417,7 +417,7 @@ export class ChatPromptInput {
       const attachmentContent: string | undefined = this.promptAttachment?.lastAttachmentContent;
       const promptText = currentInputValue + (attachmentContent ?? '');
       const context: string[] = [];
-      const escapedPrompt = escapeHTML(promptText.replace(/@\S*/gi, (match) => {
+      const escapedPrompt = escapeHTML(promptText.replace(/^\s+/gm, '').replace(/@\S*/gi, (match) => {
         if (!context.includes(match)) {
           context.push(match);
         }


### PR DESCRIPTION
## Problem
When user types empty spaces at the beginning of lines inside prompt, it appears like a code block instead of a paragraph.

## Solution
Removed empty spaces for each line.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
