### PR TITLE
Dogusata/fix prompt input does not wrap properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.15.1",
+      "version": "4.15.2",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/components/card/card-body.ts
+++ b/src/components/card/card-body.ts
@@ -91,7 +91,7 @@ export class CardBody {
 
   private readonly processNode = (node: HTMLElement): HTMLElement => {
     let elementFromNode: HTMLElement = node;
-    if (this.props.useParts === true && elementFromNode.nodeType === Node.TEXT_NODE) {
+    if (this.props.useParts === true && elementFromNode.nodeType === Node.TEXT_NODE && elementFromNode.textContent?.trim() !== '') {
       elementFromNode = DomBuilder.getInstance().build({
         type: 'span',
         classNames: [ 'mynah-ui-animation-text-content' ],

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -17,7 +17,7 @@
             flex-flow: row nowrap;
             overflow: visible;
             box-sizing: border-box;
-            gap: var(--mynah-sizing-1);
+            gap: var(--mynah-sizing-2);
             align-items: flex-start;
             position: relative;
             color: var(--mynah-color-text-weak);
@@ -67,6 +67,8 @@
                     width: 100%;
                     max-height: 20vh;
                     line-height: var(--mynah-line-height);
+                    white-space: pre-wrap;
+                    word-break: normal;
 
                     &:placeholder-shown {
                         text-overflow: ellipsis;
@@ -93,13 +95,11 @@
                 }
 
                 > .mynah-chat-prompt-input-sizer {
-                    display: block;
+                    display: inline-block;
                     width: 100%;
                     opacity: 1;
                     pointer-events: none;
-                    overflow: hidden;
-                    white-space: pre-wrap;
-                    word-break: break-word;
+                    overflow: auto;
                     color: var(--mynah-color-text-input);
                     position: relative;
                     z-index: 50;
@@ -108,6 +108,7 @@
                         color: var(--mynah-color-button-reverse);
                         border-radius: calc(var(--mynah-input-radius) / 2);
                         display: inline;
+                        white-space: nowrap;
                         &:before {
                             content: '';
                             position: absolute;


### PR DESCRIPTION
## Problem
When the prompt input text exceeds the width of the chat box it's not always wrapped correctly.

## Solution
Prompt input is properly sized and matches with the textarea underneath.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
