### PR TITLE
fix: restore command prompt when blurred then focused

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.semanticTokenColorCustomizations": {},
+  "workbench.colorTheme": "City Fog"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "editor.semanticTokenColorCustomizations": {},
-  "workbench.colorTheme": "City Fog"
-}

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -53,6 +53,7 @@ export class ChatPromptInput {
       tabId: this.props.tabId,
       onKeydown: this.handleInputKeydown,
       onInput: () => this.updateAvailableCharactersIndicator(),
+      onFocus: this.handleInputFocus,
     });
     this.remainingCharsIndicator = DomBuilder.getInstance().build({
       type: 'span',
@@ -306,6 +307,55 @@ export class ChatPromptInput {
             }
           }, 1);
         }
+      }
+    }
+  };
+
+  private readonly handleInputFocus = (): void => {
+    const inputValue = this.promptTextInput.getTextInputValue();
+    if (inputValue.startsWith('/') || inputValue.startsWith('@')) {
+      this.quickPickType = inputValue.startsWith('@') ? 'context' : 'quick-action';
+      const quickPickItems =
+        this.quickPickType === 'context'
+          ? MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).getValue('contextCommands') as QuickActionCommandGroup[]
+          : MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).getValue('quickActionCommands') as QuickActionCommandGroup[];
+      this.quickPickItemGroups = [ ...quickPickItems ];
+      this.quickPickTriggerIndex = inputValue.startsWith('@') ? inputValue.indexOf('@') : 1;
+      this.textAfter = inputValue.substring(this.quickPickTriggerIndex);
+      this.promptTextInput.setContextReplacement(this.quickPickItemGroups.length > 0);
+      const restorePreviousFilteredQuickPickItemGroups: QuickActionCommandGroup[] = [];
+      this.quickPickItemGroups.forEach((quickPickGroup: QuickActionCommandGroup) => {
+        const newQuickPickCommandGroup = { ...quickPickGroup };
+        try {
+          const searchTerm = inputValue.substring(this.quickPickTriggerIndex).match(/\S*/gi)?.[0];
+          const promptRegex = new RegExp(searchTerm ?? '', 'gi');
+          newQuickPickCommandGroup.commands = newQuickPickCommandGroup.commands.filter(command =>
+            command.command.match(promptRegex)
+          );
+          if (newQuickPickCommandGroup.commands.length > 0) {
+            restorePreviousFilteredQuickPickItemGroups.push(newQuickPickCommandGroup);
+          }
+        } catch (e) {
+          // In case the prompt is an incomplete regex
+        }
+      });
+
+      if (this.quickPickItemGroups.length > 0) {
+        this.filteredQuickPickItemGroups = [ ...restorePreviousFilteredQuickPickItemGroups ];
+        this.quickPick = new Overlay({
+          closeOnOutsideClick: true,
+          referenceElement: this.render.querySelector('.mynah-chat-prompt') as ExtendedHTMLElement,
+          dimOutside: false,
+          stretchWidth: true,
+          verticalDirection: OverlayVerticalDirection.TO_TOP,
+          horizontalDirection: OverlayHorizontalDirection.START_TO_RIGHT,
+          onClose: () => {
+            this.quickPickOpen = false;
+          },
+          children: [ this.getQuickPickItemGroups(this.filteredQuickPickItemGroups) ],
+        });
+
+        this.quickPickOpen = true;
       }
     }
   };

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -313,14 +313,10 @@ export class ChatPromptInput {
 
   private readonly handleInputFocus = (): void => {
     const inputValue = this.promptTextInput.getTextInputValue();
-    if (inputValue.startsWith('/') || inputValue.startsWith('@')) {
-      this.quickPickType = inputValue.startsWith('@') ? 'context' : 'quick-action';
-      const quickPickItems =
-        this.quickPickType === 'context'
-          ? MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).getValue('contextCommands') as QuickActionCommandGroup[]
-          : MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).getValue('quickActionCommands') as QuickActionCommandGroup[];
+    if (inputValue.startsWith('/')) {
+      const quickPickItems = MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).getValue('quickActionCommands') as QuickActionCommandGroup[];
       this.quickPickItemGroups = [ ...quickPickItems ];
-      this.quickPickTriggerIndex = inputValue.startsWith('@') ? inputValue.indexOf('@') : 1;
+      this.quickPickTriggerIndex = 1;
       this.textAfter = inputValue.substring(this.quickPickTriggerIndex);
       this.promptTextInput.setContextReplacement(this.quickPickItemGroups.length > 0);
       const restorePreviousFilteredQuickPickItemGroups: QuickActionCommandGroup[] = [];

--- a/src/components/chat-item/prompt-input/prompt-text-input.ts
+++ b/src/components/chat-item/prompt-input/prompt-text-input.ts
@@ -73,7 +73,7 @@ export class PromptTextInput {
         },
         focus: () => {
           this.render.addClass('input-has-focus');
-          if (this.props.onFocus !== undefined) {
+          if (typeof this.props.onFocus !== 'undefined') {
             this.props.onFocus();
           }
         },

--- a/src/components/chat-item/prompt-input/prompt-text-input.ts
+++ b/src/components/chat-item/prompt-input/prompt-text-input.ts
@@ -12,6 +12,7 @@ export interface PromptTextInputProps {
   contextReplacement?: boolean;
   onKeydown: (e: KeyboardEvent) => void;
   onInput?: (e: KeyboardEvent) => void;
+  onFocus?: () => void;
 }
 
 export class PromptTextInput {
@@ -72,6 +73,9 @@ export class PromptTextInput {
         },
         focus: () => {
           this.render.addClass('input-has-focus');
+          if (this.props.onFocus !== undefined) {
+            this.props.onFocus();
+          }
         },
         blur: () => {
           this.render.removeClass('input-has-focus');


### PR DESCRIPTION
## Problem

When a user types a quick action command starting with `/` or a context command starting with `@` and then loses focus, the command context is lost. When the user refocuses on the input field and continues typing, the quick pick overlay does not reappear, causing the command to never be picked up.

## Solution

- [x] Added a focus event listener to the PromptTextInput class to check the input value when the input field regains focus.
- [x] If the input value starts with / or @, the quick pick overlay is reopened, and the commands are filtered accordingly.
- [x] Ensured that the quick pick overlay behaves as expected when the user resumes typing after losing focus.
- [x] If a user previous typed half a command `/show` which filtered out 4 commands when they re-focus on the input field, only restore those 4 commands

## Preview

![restoreCommandsOnFocus](https://github.com/aws/mynah-ui/assets/75797/8acb477c-97dd-469a-9658-f1ea68f65622)

## To Do

> [!TIP]
> Tomorrow Day Problems
* `chat-prompt-input.ts` could probably use some redundancy grouping for similar functionality
* `handleInputKeydown` has a complexity score of 54  

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
