### PR TITLE
Fixed text overflow for long words in input and card prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.15.2",
+  "version": "4.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.15.2",
+      "version": "4.15.3",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.15.2",
+  "version": "4.15.3",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -270,6 +270,7 @@
             &,
             > .mynah-card-body {
                 color: var(--mynah-color-text-alternate);
+                overflow-wrap: break-word;
             }
         }
         .mynah-chat-item-card-related-content > .mynah-card {

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -69,6 +69,7 @@
                     line-height: var(--mynah-line-height);
                     white-space: pre-wrap;
                     word-break: normal;
+                    overflow-wrap: break-word;
 
                     &:placeholder-shown {
                         text-overflow: ellipsis;


### PR DESCRIPTION
## Problem

Fixing issue with long words causing overflow: [Filepaths are not wrapped](https://github.com/aws/mynah-ui/issues/76)
Version bump 4.15.3

## Solution

Using styling to introduce word break.
Should cover cases like long path, class name or namespace.

<img width="501" alt="Screenshot 2024-07-16 at 16 30 10" src="https://github.com/user-attachments/assets/b1d2ae7b-ae9e-42bc-b9cf-bed25f7bcc80">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
