### PR TITLE
fix(tabs): Make max tabs notification dismissible and allow external configuration

### DIFF
--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -51,6 +51,8 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
     },
     config: {
       maxTabs: 5,
+      maxReachedOverlayDuration: 5000,
+      noMoreTabsTooltip: 'You can only open five conversation tabs at a time.',
       autoFocus: true,
       tabBarButtons: [
         {

--- a/src/components/navigation-tabs.ts
+++ b/src/components/navigation-tabs.ts
@@ -16,10 +16,13 @@ import { TabBarButtonsWrapper } from './navigation-tab-bar-buttons';
 import { Overlay, OverlayHorizontalDirection, OverlayVerticalDirection } from './overlay';
 import { Toggle, ToggleOption } from './toggle';
 import '../styles/components/_nav-tabs.scss';
+import { DEFAULT_TIMEOUT } from './notification';
 
 export interface TabsProps {
   onChange?: (selectedTabId: string) => void;
+  noMoreTabsTooltip?: string;
   onBeforeTabRemove?: (tabId: string) => boolean;
+  maxReachedOverlayDuration?: number;
 }
 export class Tabs {
   render: ExtendedHTMLElement;
@@ -115,7 +118,7 @@ export class Tabs {
         additionalEvents: {
           mouseenter: (e) => {
             if (MynahUITabsStore.getInstance().tabsLength() === Config.getInstance().config.maxTabs) {
-              this.showMaxReachedOverLay(e.currentTarget, Config.getInstance().config.texts.noMoreTabsTooltip);
+              this.showMaxReachedOverLay(e.currentTarget, this.props.noMoreTabsTooltip ?? Config.getInstance().config.texts.noMoreTabsTooltip, this.props.maxReachedOverlayDuration);
             }
           },
           mouseleave: () => {
@@ -134,7 +137,7 @@ export class Tabs {
     ];
   };
 
-  private readonly showMaxReachedOverLay = (elm: HTMLElement, markdownText: string): void => {
+  private readonly showMaxReachedOverLay = (elm: HTMLElement, markdownText: string, duration?: number): void => {
     this.maxReachedOverlay = new Overlay({
       background: true,
       closeOnOutsideClick: false,
@@ -155,6 +158,16 @@ export class Tabs {
         }).render
       ],
     });
+
+    if (duration !== undefined && duration !== -1) {
+      setTimeout(() => {
+        this.hideMaxReachedOverLay();
+      }, duration);
+    } else if (duration === undefined) {
+      setTimeout(() => {
+        this.hideMaxReachedOverLay();
+      }, DEFAULT_TIMEOUT);
+    }
   };
 
   private readonly hideMaxReachedOverLay = (): void => {

--- a/src/components/notification.ts
+++ b/src/components/notification.ts
@@ -12,6 +12,8 @@ import '../styles/components/_notification.scss';
 
 type NotificationContentType = string | ExtendedHTMLElement | HTMLElement | DomBuilderObject;
 
+export const DEFAULT_TIMEOUT = 5000;
+
 export interface NotificationProps {
   duration?: number;
   type?: NotificationType;
@@ -28,7 +30,7 @@ export class Notification {
   private readonly props;
 
   constructor (props: NotificationProps) {
-    this.duration = props.duration !== undefined ? props.duration : 5000;
+    this.duration = props.duration !== undefined ? props.duration : DEFAULT_TIMEOUT;
     this.type = props.type ?? NotificationType.INFO;
     this.props = props;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -289,6 +289,8 @@ export class MynahUI {
             this.props.onTabChange(selectedTabId, this.getUserEventId());
           }
         },
+        maxReachedOverlayDuration: Config.getInstance().config.maxReachedOverlayDuration,
+        noMoreTabsTooltip: Config.getInstance().config.noMoreTabsTooltip,
         onBeforeTabRemove: (tabId): boolean => {
           if (props.onBeforeTabRemove !== undefined) {
             return props.onBeforeTabRemove(tabId, this.getUserEventId());

--- a/src/static.ts
+++ b/src/static.ts
@@ -431,6 +431,8 @@ export interface ConfigOptions {
   }>;
   tabBarButtons?: TabBarMainAction[];
   maxTabs: number;
+  maxReachedOverlayDuration?: number;
+  noMoreTabsTooltip?: string;
   showPromptField: boolean;
   autoFocus: boolean;
   maxUserInput: number;


### PR DESCRIPTION
## Problem

Currently the notification for max tabs isn't dismissible. Also, isn't possible the implementation overwrite the defaults (duration / tooltip text).

![notification](https://github.com/user-attachments/assets/c736e164-f232-43d8-8291-c4d9b9e3e118)

## Solution

Add maxReachedOverlayDuration (to adjust the duration / fallbacks to default 5000) to use as a dismiss duration and noMoreTabsTooltip exposable for messaging configuration.

![notification](https://github.com/user-attachments/assets/a78b76a3-8d85-4f5c-b24b-3e978673577e)

Note: I've tried to update the changelog with newChange, but doesn't seems to have the script.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
