### PR TITLE
fix: #76 feature: markdown table styles feature: all markdown tags

### DIFF
--- a/example/src/commands.ts
+++ b/example/src/commands.ts
@@ -6,6 +6,8 @@ export enum Commands {
     STATUS_CARDS = '/cards-with-status-colors',
     FORM_CARD = '/card-with-a-form',
     CARD_WITH_MARKDOWN_LIST = '/card-with-markdown-list',
+    CARD_WITH_ALL_MARKDOWN_TAGS = '/card-with-all-markdown-tags',
+    CARD_RENDER_MARKDOWN_TABLE = '/card-render-markdown-table',
     CARD_SNAPS_TO_TOP = '/card-snaps-to-top',
     FILE_LIST_CARD = '/card-with-a-file-list',
     PROGRESSIVE_CARD = '/card-with-progressing-content',

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -4,10 +4,11 @@ import {
 import { defaultFollowUps } from './samples/sample-data';
 import { Commands } from './commands';
 import { MynahUITabStoreTab, QuickActionCommandGroup } from '../../dist/static';
-export const WelcomeMessage = `Hi, this is \`MynahUI\` and it is a **data and event driven** web based chat interface library and it is independent from any framework like react or vue etc. 
-In this example web app which uses mynah-ui as its renderer, we're simulating its capabilities with some static content with an IDE look&feel. 
+export const WelcomeMessage = `Hi, this is \`MynahUI\` and it is a **data and event driven** web based chat interface library and it is independent from any framework like react or vue etc.
+In this example web app which uses mynah-ui as its renderer, we're simulating its capabilities with some static content with an IDE look&feel.
 
-*To see more examples about the possible content types, interactions or various component types, you can type \`/\` to open the quick actions list panel.*`;
+*To see more examples about the possible content types, interactions or various component types, you can type \`/\` to open the quick actions list panel.*
+`;
 
 export const QuickActionCommands:QuickActionCommandGroup[] = [
   {
@@ -31,7 +32,7 @@ export const QuickActionCommands:QuickActionCommandGroup[] = [
         command: Commands.SHOW_STICKY_CARD,
         description: 'You can stick a ChatItem card on top of the input field which will stay there independently from the conversation block. It might be handy to give some info to the user.',
       },
-      
+
     ],
   },
   {
@@ -52,6 +53,14 @@ export const QuickActionCommands:QuickActionCommandGroup[] = [
       {
         command: Commands.CARD_WITH_MARKDOWN_LIST,
         description: 'ChatItem card with a complex markdown list inside.',
+      },
+      {
+        command: Commands.CARD_WITH_ALL_MARKDOWN_TAGS,
+        description: 'ChatItem card with a markdown file with all markdown tags',
+      },
+      {
+        command: Commands.CARD_RENDER_MARKDOWN_TABLE,
+        description: 'ChatItem card for markdown table',
       },
       {
         command: Commands.CARD_SNAPS_TO_TOP,

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -30,6 +30,8 @@ import {
   sampleMarkdownList,
   exampleCodeDiff,
   exampleCodeDiffApplied,
+  sampleAllInOneList,
+  sampleTableList,
 } from './samples/sample-data';
 import escapeHTML from 'escape-html';
 import './styles/styles.scss';
@@ -335,11 +337,27 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
         case Commands.CARD_WITH_MARKDOWN_LIST:
           getGenerativeAIAnswer(tabId, sampleMarkdownList);
           break;
+        case Commands.CARD_WITH_ALL_MARKDOWN_TAGS:
+          mynahUI.addChatItem(tabId, {
+            type: ChatItemType.ANSWER,
+            messageId: generateUID(),
+            body: sampleAllInOneList.slice(-1)[0].body,
+            snapToTop: true
+          });
+          break;
+        case Commands.CARD_RENDER_MARKDOWN_TABLE:
+          mynahUI.addChatItem(tabId, {
+            type: ChatItemType.ANSWER,
+            messageId: generateUID(),
+            body: sampleTableList.slice(-1)[0].body,
+            snapToTop: true
+          });
+          break;
         case Commands.CARD_SNAPS_TO_TOP:
           mynahUI.addChatItem(tabId, {
             type: ChatItemType.ANSWER,
             messageId: generateUID(),
-            body: sampleMarkdownList.slice(-1)[0].body, 
+            body: sampleMarkdownList.slice(-1)[0].body,
             snapToTop: true
           });
           mynahUI.addChatItem(tabId, defaultFollowUps);

--- a/example/src/samples/sample-all-in-one.md
+++ b/example/src/samples/sample-all-in-one.md
@@ -1,0 +1,148 @@
+
+# Markdown Examples
+
+## Headings
+
+### Example
+
+# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6
+
+
+## Emphasis
+
+### Example
+
+*Italic text*
+
+_Italic text_
+
+**Bold text**
+
+__Bold text__
+
+***Bold and italic text***
+
+___Bold and italic text___
+
+
+## Lists
+
+### Unordered List Example
+
+- Item 1
+- Item 2
+  - Subitem 1
+  - Subitem 2
+
+
+### Ordered List Example
+
+1. Item 1
+2. Item 2
+   1. Subitem 1
+   2. Subitem 2
+
+
+## Links
+
+### Example
+
+[mynah-ui](https://github.com/aws/mynah-ui)
+
+<https://github.com/aws/mynah-ui>
+
+
+## Images
+
+### Example
+
+![Alt text](https://placehold.co/600x400)
+
+
+## Blockquotes
+
+### Example
+
+> This is a blockquote.
+
+
+## Code
+
+### Inline Code Example
+Here is some `inline code`.
+
+### Block Code Example
+This is a block of code.
+```
+no syntax declared
+```
+
+### Syntax Highlighting Example
+
+```javascript
+const x;
+```
+
+
+## Tables
+
+### Example
+
+| left aligned | center aligned | natural alignment | right aligned |
+| :------- | :-----: | -------- | -------: |
+| 1   | 1   | 1 | 1 |
+| 2   | 2   | 2 | 2 |
+
+
+## Horizontal Rule
+
+### Example
+
+---
+
+***
+
+___
+
+## Task Lists
+
+### Example
+
+- [x] Task 1
+- [ ] Task 2
+- [ ] Task 3
+
+
+## Footnotes
+
+### Example
+
+Here is a footnote reference[^1].
+
+[^1]: Here is the footnote.
+
+
+## Strikethrough
+
+### Example
+
+~~Strikethrough text~~
+
+
+## HTML
+
+### Example
+
+<p>This is an HTML paragraph.</p>
+
+## Collapsible
+
+<details>
+  <summary>Summary</summary>
+	Detail
+</details>

--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -18,6 +18,8 @@ import sampleList4 from './sample-list-4.md';
 import SampleCode from './sample-code.md';
 import SampleDiff from './sample-diff.md';
 import SampleDiffApplied from './sample-diff-applied.md';
+import SampleAllInOne from './sample-all-in-one.md'
+import SampleTable from './sample-table.md'
 import { Commands } from '../commands';
 
 export const mynahUIQRImageBase64 =
@@ -46,8 +48,8 @@ export const exampleSources = [
         body: `To see how to configure statics for MynahUI please refer to **[Configuration](./CONFIG.md)** document.
 
   Lastly before you start reading here, you can find more details on the **[Data Model](./DATAMODEL.md)** document. That document also contains visuals related with each type of the chat message in detail.
-  
-  
+
+
   #### All publicly available functions
   \`\`\`typescript
   mynahUI.addChatItem(...);
@@ -67,6 +69,14 @@ export const sampleMarkdownList: Partial<ChatItem>[] = [
     { body: `${sampleList2 as string}` },
     { body: `${sampleList3 as string}` },
     { body: `${sampleList4 as string}` },
+];
+
+export const sampleAllInOneList: Partial<ChatItem>[] = [
+    { body: `${SampleAllInOne as string}`},
+];
+
+export const sampleTableList: Partial<ChatItem>[] = [
+    { body: `${SampleTable as string}`},
 ];
 
 export const exampleStreamParts: Partial<ChatItem>[] = [
@@ -157,6 +167,14 @@ export const defaultFollowUps: ChatItem = {
             {
                 command: Commands.CARD_WITH_MARKDOWN_LIST,
                 pillText: 'Markdown list',
+            },
+            {
+                command: Commands.CARD_WITH_ALL_MARKDOWN_TAGS,
+                pillText: 'All markdown tags',
+            },
+            {
+                command: Commands.CARD_RENDER_MARKDOWN_TABLE,
+                pillText: 'Render markdown table',
             },
             {
                 command: Commands.CARD_SNAPS_TO_TOP,
@@ -262,7 +280,7 @@ export const exampleFileListChatItemForUpdate: Partial<ChatItem> = {
 export const exampleFormChatItem: ChatItem = {
     type: ChatItemType.ANSWER,
     messageId: new Date().getTime().toString(),
-    body: `Can you help us to improve our AI Assistant? Please fill the form below and hit **Submit** to send your feedback.  
+    body: `Can you help us to improve our AI Assistant? Please fill the form below and hit **Submit** to send your feedback.
 
 _To send the form, mandatory items should be filled._`,
     formItems: [
@@ -526,7 +544,7 @@ export const exampleImageCard = (): ChatItem => {
         body: `
 ### Image!
 Here's a QR code for mynah-ui github link:
-  
+
 ${mynahUIQRMarkdown}
 `,
     };
@@ -619,7 +637,7 @@ You can find more information and references <strong><a href="https://github.com
 <br />
 
 <p>There might be infinite number of possible examples with all supported tags and their attributes. It doesn't make so much sense to demonstrate all of them here.
-You should go take a look to the <strong><a href="https://github.com/aws/mynah-ui/blob/main/docs/DATAMODEL.md">documentation</a></strong> for details and limitations.</p> 
+You should go take a look to the <strong><a href="https://github.com/aws/mynah-ui/blob/main/docs/DATAMODEL.md">documentation</a></strong> for details and limitations.</p>
 `,
     };
 };

--- a/example/src/samples/sample-table.md
+++ b/example/src/samples/sample-table.md
@@ -1,0 +1,10 @@
+# Project Features Overview
+
+| Feature           | Description                                      | Priority   | Status       |
+|:------------------|--------------------------------------------------|:----------:|-------------:|
+| User Authentication | Implement secure login and registration         | High       | In Progress  |
+| Dashboard         | Create a user dashboard with key metrics         | Medium     | Planned      |
+| Reporting         | Generate monthly performance reports             | Low        | Not Started  |
+| Notifications     | Add email and push notifications for updates     | Medium     | In Progress  |
+| API Integration   | Integrate third-party APIs for data enrichment   | High       | Completed    |
+| User Feedback     | Collect and analyze user feedback                | Low        | Not Started  |

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -1,5 +1,6 @@
 @import '../variables';
 @import '../mixins';
+
 pre.diff-highlight > code .token.deleted:not(.prefix),
 pre > code.diff-highlight .token.deleted:not(.prefix) {
     background-color: rgba(255, 0, 0, 0.1);
@@ -135,23 +136,17 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             font-size: var(--mynah-syntax-code-font-size) !important;
             font-family: var(--mynah-syntax-code-font-family) !important;
         }
+
         code {
             color: var(--mynah-color-syntax-code);
             filter: brightness(0.95);
-            white-space: pre;
             background-color: inherit;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            overflow-wrap: anywhere;
+            word-break: break-all;
         }
 
-        > code,
-        & {
-            text-align: left;
-            white-space: pre;
-            word-spacing: normal;
-            word-break: normal;
-            word-wrap: normal;
-            tab-size: 4;
-            hyphens: none;
-        }
         > code::selection,
         &::selection {
             text-shadow: none;

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -140,12 +140,24 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
         code {
             color: var(--mynah-color-syntax-code);
             filter: brightness(0.95);
+            white-space: pre;
+            background-color: inherit;
+        }
+
+        /**
+        * Apply the default styles to the code block.
+        * Should we decide to use word wrapping in the future, we can uncomment the following lines.
+        * We would need to add line numberes to the code block as well.
+        code {
+            color: var(--mynah-color-syntax-code);
+            filter: brightness(0.95);
             background-color: inherit;
             white-space: pre-wrap;
             word-wrap: break-word;
             overflow-wrap: anywhere;
             word-break: break-all;
         }
+        */
 
         > code::selection,
         &::selection {

--- a/src/styles/components/card/_card-body.scss
+++ b/src/styles/components/card/_card-body.scss
@@ -7,7 +7,6 @@
   display: block;
   line-height: var(--mynah-line-height);
   font-size: var(--mynah-font-size-medium);
-  overflow-wrap: anywhere;
   word-break: break-all;
 
   &:empty {

--- a/src/styles/components/card/_card-body.scss
+++ b/src/styles/components/card/_card-body.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 .mynah-card-body {
   flex-shrink: 0;
   overflow: hidden;
@@ -5,6 +7,8 @@
   display: block;
   line-height: var(--mynah-line-height);
   font-size: var(--mynah-font-size-medium);
+  overflow-wrap: anywhere;
+  word-break: break-all;
 
   &:empty {
     display: none;
@@ -81,8 +85,26 @@
       border: none;
       font-size: inherit;
     }
+
     table {
       table-layout: fixed;
+
+      thead {
+        background: var(--mynah-color-bg);
+      }
+
+      tbody {
+        tr:nth-child(even) {
+          background: var(--mynah-color-bg);
+        }
+      }
+    }
+
+    table, tr, th, td {
+      border: var(--mynah-border-width) solid var(--mynah-color-border-default);
+      border-collapse: collapse;
+      padding: var(--mynah-sizing-2);
+      word-break: auto-phrase;
     }
 
     // BLOCKS

--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -9,6 +9,8 @@
     opacity: 0;
     transform-origin: center bottom;
     gap: var(--mynah-sizing-4);
+    overflow-wrap: anywhere;
+    word-break: break-all;
 
     &-status {
         @each $status in $mynah-statuses {

--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -9,7 +9,7 @@
     opacity: 0;
     transform-origin: center bottom;
     gap: var(--mynah-sizing-4);
-    overflow-wrap: anywhere;
+    overflow-wrap: break-word;
     word-break: break-all;
 
     &-status {


### PR DESCRIPTION
## Problem

This resolves #76 

> Enter text into the mynah chatbox like awdaw/dawdaw/dawda/wdawdaw/dawdawd/awdad/awdawd/awdaw/dawd/, observe that when you enter the message, the text is not wrapped.
>
> From testing on the team, changing word-wrap css to break-word fixes this.

## Solution

### Code blocks

```css
code {
    color: var(--mynah-color-syntax-code);
    filter: brightness(0.95);
    background-color: inherit;
    white-space: pre-wrap;
    word-wrap: break-word;
    overflow-wrap: anywhere;
    word-break: break-all;
}
```
<img width="702" alt="Screenshot 2024-07-18 at 4 50 49 PM" src="https://github.com/user-attachments/assets/b681d24c-49b8-4e3a-bd27-e9668a878a8f">

### Markdown table rendering

```css
table {
  table-layout: fixed;

  thead {
    background: var(--mynah-color-bg);
  }

  tbody {
    tr:nth-child(even) {
      background: var(--mynah-color-bg);
    }
  }
}

table, tr, th, td {
  border: var(--mynah-border-width) solid var(--mynah-color-border-default);
  border-collapse: collapse;
  padding: var(--mynah-sizing-2);
  word-break: auto-phrase;
}
```


### Additionally added two more commands
* `CARD_WITH_ALL_MARKDOWN_TAGS`
* `CARD_RENDER_MARKDOWN_TABLE`

> CARD_WITH_ALL_MARKDOWN_TAGS

This will render all markdown tags

<img width="712" alt="Screenshot 2024-07-18 at 4 55 34 PM" src="https://github.com/user-attachments/assets/fd5d1d46-d9c5-437c-99f6-eef02ac5ac52">


> CARD_RENDER_MARKDOWN_TABLE

This now makes markdown tables render as expected with backgrounds and borders

<img width="709" alt="Screenshot 2024-07-18 at 4 51 15 PM" src="https://github.com/user-attachments/assets/c8dfda24-a099-44d5-a6e0-71e554bbedf3">

> [!TIP]
> How to test really long strings

You can test locally by editing `examples/src/config.ts` by adding the below to `WelcomeMessage`

```typescript
here is a really long word WITH quotes\`pneumonoultramicroscopicsilicovolcanoconiosispneumonoultramicroscopicsilicovolcanoconiosis\`

here is a really long word WITHOUT quotes pneumonoultramicroscopicsilicovolcanoconiosispneumonoultramicroscopicsilicovolcanoconiosis

here is a really lone file path WITH quotes \`C:\\Users\\JohnDoe\\Documents\\Projects\\2024\\Q3\\CustomerEngagement\\Phase2\\FinalReports\\Drafts\\Version3\\Images\\Marketing\\HighRes\\JPEG\\Export\\2024_07_18_Customer_Engagement_Final_Report_Version3_Draft_Marketing_HighRes_Images_JPEG_Export_Backup_Copy_20240718.pdf\`

here is a really lone file path WITHOUT quotes C:\\Users\\JohnDoe\\Documents\\Projects\\2024\\Q3\\CustomerEngagement\\Phase2\\FinalReports\\Drafts\\Version3\\Images\\Marketing\\HighRes\\JPEG\\Export\\2024_07_18_Customer_Engagement_Final_Report_Version3_Draft_Marketing_HighRes_Images_JPEG_Export_Backup_Copy_20240718.pdf

# Project Features Overview

| Feature           | Description                                      | Priority   | Status       |
|:------------------|--------------------------------------------------|:----------:|-------------:|
| User Authentication | Implement secure login and registration         | High       | In Progress  |
| Dashboard         | Create a user dashboard with key metrics         | Medium     | Planned      |
| Reporting         | Generate monthly performance reports             | Low        | Not Started  |
| Notifications     | Add email and push notifications for updates     | Medium     | In Progress  |
| API Integration   | Integrate third-party APIs for data enrichment   | High       | Completed    |
| User Feedback     | Collect and analyze user feedback                | Low        | Not Started  |
```



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
