### PR TITLE
fix: #81 scrollbar

### DIFF
--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -4,8 +4,8 @@ import {
 import { defaultFollowUps } from './samples/sample-data';
 import { Commands } from './commands';
 import { MynahUITabStoreTab, QuickActionCommandGroup } from '../../dist/static';
-export const WelcomeMessage = `Hi, this is \`MynahUI\` and it is a **data and event driven** web based chat interface library and it is independent from any framework like react or vue etc. 
-In this example web app which uses mynah-ui as its renderer, we're simulating its capabilities with some static content with an IDE look&feel. 
+export const WelcomeMessage = `Hi, this is \`MynahUI\` and it is a **data and event driven** web based chat interface library and it is independent from any framework like react or vue etc.
+In this example web app which uses mynah-ui as its renderer, we're simulating its capabilities with some static content with an IDE look&feel.
 
 *To see more examples about the possible content types, interactions or various component types, you can type \`/\` to open the quick actions list panel.*`;
 
@@ -31,7 +31,7 @@ export const QuickActionCommands:QuickActionCommandGroup[] = [
         command: Commands.SHOW_STICKY_CARD,
         description: 'You can stick a ChatItem card on top of the input field which will stay there independently from the conversation block. It might be handy to give some info to the user.',
       },
-      
+
     ],
   },
   {

--- a/src/styles/_scrollbars.scss
+++ b/src/styles/_scrollbars.scss
@@ -1,0 +1,8 @@
+* {
+  scrollbar-gutter: unset;
+  scrollbar-color: color-mix(
+    in hsl,
+    var(--mynah-color-text-default),
+    hsl(0, 100%, 100%) 90%)
+    transparent;
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -3,4 +3,5 @@
 @import 'animations';
 @import 'dark';
 @import 'favicons';
+@import 'scrollbars';
 @import './components/main-container';


### PR DESCRIPTION
## Problem

## Solution

Everything that needs / requires a scrollbar predicated by overflow conditions now has a scrollbar
* The gutter is `unset` meaning, it won't be there and be ugly.
* The draggable part is colored using css color mix blended in with white hs; `hsl(0, 100%, 100%)` @ `90%` which stays within the theme, and considerable enough for visual distinction

```
* {
  scrollbar-gutter: unset;
  scrollbar-color: color-mix(
    in hsl,
    var(--mynah-color-text-default),
    hsl(0, 100%, 100%) 90%)
    transparent;
}
```
<img width="1659" alt="Screenshot 2024-07-19 at 8 03 03 AM" src="https://github.com/user-attachments/assets/e73123a4-02f1-4f1e-860b-774589090469">


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
