### PR TITLE
fix: header in card not wrapping

### DIFF
--- a/src/styles/components/card/_card-body.scss
+++ b/src/styles/components/card/_card-body.scss
@@ -53,6 +53,9 @@
     h4,
     h5,
     h6 {
+      word-break: normal;
+      overflow-wrap: break-word;
+      line-height: calc(var(--mynah-line-height) * 1.25);
       margin-block-start: 0.75em;
       margin-block-end: 0.75em;
       padding-bottom: 1px !important;


### PR DESCRIPTION
## Problem

Header does not seem to wrap well with default `word-wrap: normal`

## Solution

before: 
<img width="495" alt="image" src="https://github.com/user-attachments/assets/3e80c7bc-024c-4361-b61f-ea0b2544dd7e">

after:
<img width="469" alt="image" src="https://github.com/user-attachments/assets/16fefd47-45e0-49f7-9627-be97f88dea4c">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
