### PR TITLE
Fixed link preview overlays remaining on screen sometimes

### DIFF
--- a/src/components/source-link/source-link-header.ts
+++ b/src/components/source-link/source-link-header.ts
@@ -41,8 +41,6 @@ export class SourceLinkHeader {
         ? {
             events: {
               mouseenter: (e) => {
-                // If it is already there
-                this.hideLinkPreview();
                 this.showLinkPreview(e, props.sourceLink);
               },
               mouseleave: this.hideLinkPreview,

--- a/src/components/source-link/source-link-header.ts
+++ b/src/components/source-link/source-link-header.ts
@@ -5,8 +5,9 @@
 
 import { getTimeDiff } from '../../helper/date-time';
 import { DomBuilder, DomBuilderObject, ExtendedHTMLElement } from '../../helper/dom';
+import { MynahUIGlobalEvents } from '../../helper/events';
 import { getOrigin } from '../../helper/url';
-import { SourceLink, SourceLinkMetaData } from '../../static';
+import { MynahEventNames, SourceLink, SourceLinkMetaData } from '../../static';
 import { Icon, MynahIcons } from '../icon';
 import { Overlay, OverlayHorizontalDirection, OverlayVerticalDirection } from '../overlay';
 import { SourceLinkCard } from './source-link';
@@ -28,6 +29,11 @@ export class SourceLinkHeader {
     if (splitUrl[splitUrl.length - 1].trim() === '') {
       splitUrl.pop();
     }
+    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.ROOT_FOCUS, (data: {focusState: boolean}) => {
+      if (!data.focusState) {
+        this.hideLinkPreview();
+      }
+    });
     this.render = DomBuilder.getInstance().build({
       type: 'div',
       classNames: [ 'mynah-source-link-header' ],
@@ -35,6 +41,8 @@ export class SourceLinkHeader {
         ? {
             events: {
               mouseenter: (e) => {
+                // If it is already there
+                this.hideLinkPreview();
                 this.showLinkPreview(e, props.sourceLink);
               },
               mouseleave: this.hideLinkPreview,

--- a/src/styles/components/_overlay.scss
+++ b/src/styles/components/_overlay.scss
@@ -28,12 +28,12 @@
         --overlayInnerVerticalOrigin: top;
         position: absolute;
         display: block;
-        overflow: visible;
+        overflow: hidden;
         border-radius: var(--mynah-card-radius);
-        max-width: calc(100vw - var(--mynah-sizing-8))!important;
         width: max-content;
         height: max-content;
-        max-height: calc(100vh - var(--mynah-sizing-8))!important;
+        max-width: calc(100vw - var(--mynah-sizing-16))!important;
+        max-height: calc(100vh - var(--mynah-sizing-16))!important;
 
         .mynah-card,
         .mynah-card * {


### PR DESCRIPTION
## Problem
Sometimes related link overlay (details) remain on screen and makes the UI panel unusable.

## Solution
- Added a check if window looses focus then removes the active overlay for related link previews.
- Updated max width and height of the overlays to let user focus on some other point to automatically hide overlay items
- If content exceeds overlay size, it will not bleed from the edges anymore (`overflow: hidden`)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
