### PR TITLE
Fix conflict of @ context selections and user intended annotations start with @

### DIFF
--- a/src/components/chat-item/prompt-input/prompt-text-input.ts
+++ b/src/components/chat-item/prompt-input/prompt-text-input.ts
@@ -13,6 +13,7 @@ export interface PromptTextInputProps {
   tabId: string;
   initMaxLength: number;
   contextReplacement?: boolean;
+  contextItems?: string[];
   onKeydown: (e: KeyboardEvent) => void;
   onInput?: (e: KeyboardEvent) => void;
   onFocus?: () => void;
@@ -149,7 +150,12 @@ export class PromptTextInput {
     }
     let visualisationValue = escapeHTML(this.promptTextInput.value);
     if (this.props.contextReplacement === true) {
-      visualisationValue = `${visualisationValue.replace(/@\S*/gi, (match) => `<span class="context">${match}</span>`)}&nbsp`;
+      visualisationValue = `${visualisationValue.replace(/@\S*/gi, (match) => {
+        if ((this.props.contextItems == null) || !this.props.contextItems.includes(match)) {
+          return match;
+        }
+        return `<span class="context">${match}</span>`;
+      })}&nbsp`;
     }
     // HTML br element, which gives a new line, will not work without a content if it is placed at the end of the parent node
     // If it doesn't take effect, first new line step won't work with shift+enter
@@ -275,5 +281,9 @@ export class PromptTextInput {
         placeholder: text,
       }
     });
+  };
+
+  public readonly updateContextItems = (contextItems: string[]): void => {
+    this.props.contextItems = contextItems;
   };
 }


### PR DESCRIPTION
## Problem
It is not possible to write any text which starts with @ character if they are not in the available contexts list. And if it is in the context list, it works as a context instead of user intended text.

## Solution
- Added checks to avoid removal of the word if it starts with @ character and not in the available context selection list
- Added checks to send only the words start with @ character in the available context items list as part of the prompt object
- Added checks to paint only the words start with @ character in the available context items list, otherwise keep as normal texts

Here's how it works:
<video width="500" height="500" src='https://github.com/user-attachments/assets/68ed9202-7110-4c9f-bc28-8b988ab9182e' />


NOTE: Even though the word is partially matching with one of the context items available, users are able to hit `esc` and proceed with their own texts. For example: after writing `@cod` if user directly hits space, it will automatically select `@code` as a context item. But if user hits escape and close the selector overlay, they can leave it as `@cod`.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
