### PR TITLE
fix: quick action handling edge case not filtering disabled command

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -480,7 +480,7 @@ export class ChatPromptInput {
       if (selectedCommand === '') {
         for (const quickPickItem of quickPickItems) {
           if (selectedCommand !== '') break;
-          const matchedCommand = quickPickItem.commands.find((item) => currentInputValue.startsWith(item.command));
+          const matchedCommand = quickPickItem.commands.find((item) => item.disabled === false && currentInputValue.startsWith(item.command));
           if (matchedCommand !== undefined) {
             selectedCommand = matchedCommand.command;
           }


### PR DESCRIPTION
## Problem

Matched command is not filtering disabled command, allowing disabled command to be bypassed

## Solution

Filter disabled command when finding the prompt & quick command match

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
