### PR TITLE
Fix code indentation and nested formatting issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.15.6",
+  "version": "4.15.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.15.6",
+      "version": "4.15.7",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.15.6",
+  "version": "4.15.7",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -497,7 +497,7 @@ export class ChatPromptInput {
 
       const quickPickContextItems = (MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).getValue('contextCommands') as QuickActionCommandGroup[]) ?? [];
       const allQuickPickContextItems = quickPickContextItems.flatMap(cntxGroup => cntxGroup.commands.map(cmd => cmd.command));
-      const escapedPrompt = escapeHTML(promptText.replace(/^\s+/gm, '').replace(/@\S*/gi, (match) => {
+      const escapedPrompt = escapeHTML(promptText.replace(/@\S*/gi, (match) => {
         if (!context.includes(match) && allQuickPickContextItems.includes(match)) {
           context.push(match);
         }


### PR DESCRIPTION
## Problem

The problem is described in related GitHub issue: https://github.com/aws/mynah-ui/issues/97

## Solution

Revert fix for [another issue](https://github.com/aws/mynah-ui/issues/70) that is removing leading whitespace characters from the prompt. The previous fix is causing more impacting formatting issues. Also, the [change](https://github.com/aws/mynah-ui/issues/70) requested is not a bug, but a feature request. Current MynahUI treats any prompt as markdown, where [4 leading whitespaces means code block](https://www.markdownguide.org/basic-syntax/#code-blocks). Current MynahUI does not provide an option to input prompt as a plain text.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
