### PR TITLE
Fix copy/paste for inline code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.15.7",
+  "version": "4.15.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.15.7",
+      "version": "4.15.8",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.15.7",
+  "version": "4.15.8",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -98,32 +98,31 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
         margin-right: 2px;
         background-color: transparent !important;
         vertical-align: middle;
-        padding-bottom: 1px !important;
-        margin-bottom: 2px;
-        > pre {
+        &,
+        & * {
             padding: 0;
-            display: inline-block;
+            user-select: text;
+            display: inline;
         }
-        &:after {
+
+        &:after,
+        &:before {
             content: '';
             position: absolute;
-            box-sizing: border-box;
-            top: -1px;
-            height: calc(100% + 2px);
+            top: -2px;
+            height: calc(100% + 4px);
             left: -4px;
             width: calc(100% + 8px);
             border-radius: var(--mynah-input-radius);
+            box-sizing: border-box;
+        }
+        &:after {
             border: var(--mynah-border-width) solid var(--mynah-color-border-default);
             background-color: var(--mynah-card-bg);
             z-index: -1;
         }
         &:before {
-            top: -1px;
-            height: calc(100% + 2px);
-            left: -4px;
-            width: calc(100% + 8px);
-            border-radius: var(--mynah-input-radius);
-            box-sizing: border-box;
+            background-color: var(--mynah-color-syntax-bg);
         }
     }
     > pre {

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -84,7 +84,7 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
         }
     }
     &.mynah-inline-code {
-        display: inline-flex;
+        display: inline-block;
         max-width: 100%;
         line-height: normal;
         padding: 0 !important;
@@ -96,11 +96,13 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
         color: var(--mynah-color-syntax-attr);
         margin-left: 2px;
         margin-right: 2px;
-        padding-bottom: 1px !important;
-        margin-bottom: -1px;
         background-color: transparent !important;
+        vertical-align: middle;
+        padding-bottom: 1px !important;
+        margin-bottom: 2px;
         > pre {
             padding: 0;
+            display: inline-block;
         }
         &:after {
             content: '';

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -86,7 +86,7 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
     &.mynah-inline-code {
         display: inline-block;
         max-width: 100%;
-        line-height: normal;
+        line-height: inherit;
         padding: 0 !important;
         margin: 0;
         margin-block-start: 0;
@@ -96,6 +96,7 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
         color: var(--mynah-color-syntax-attr);
         margin-left: 2px;
         margin-right: 2px;
+        margin-top: -2px;
         background-color: transparent !important;
         vertical-align: middle;
         &,
@@ -103,15 +104,15 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
         & > pre > code {
             padding: 0;
             user-select: text;
-            display: inline;
+            display: inline-block;
         }
 
         &:after,
         &:before {
             content: '';
             position: absolute;
-            top: -2px;
-            height: calc(100% + 4px);
+            top: 0px;
+            height: 100%;
             left: -4px;
             width: calc(100% + 8px);
             border-radius: var(--mynah-input-radius);

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -99,7 +99,8 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
         background-color: transparent !important;
         vertical-align: middle;
         &,
-        & * {
+        & > pre,
+        & > pre > code {
             padding: 0;
             user-select: text;
             display: inline;


### PR DESCRIPTION
## Problem

If you copy from the Mynah card with inline code and paste it into another place, it will contain new line breaks around inline code text.
The problem is described in more details in related issue: https://github.com/aws/mynah-ui/issues/98

## Solution

Avoid using block elements for inline code.

Before:
![Screenshot 2024-08-21 at 18 12 28](https://github.com/user-attachments/assets/23d9a52a-2a85-4460-8cad-d9e23c651616)
After:
![Screenshot 2024-08-21 at 18 12 44](https://github.com/user-attachments/assets/26e2538b-b1b3-4630-b389-bdb6be9b53ee)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
