### PR TITLE
Latest VSCode and MynahUI, inline codes are not aligned with normal texts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.15.8",
+  "version": "4.15.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.15.8",
+      "version": "4.15.9",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.15.8",
+  "version": "4.15.9",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -105,18 +105,21 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             padding: 0;
             user-select: text;
             display: inline-block;
+            position: relative;
+            vertical-align: middle;
         }
 
         &:after,
         &:before {
             content: '';
             position: absolute;
-            top: 0px;
-            height: 100%;
+            top: 50%;
+            height: var(--mynah-line-height);
             left: -4px;
             width: calc(100% + 8px);
             border-radius: var(--mynah-input-radius);
             box-sizing: border-box;
+            transform: translateY(-50%);
         }
         &:after {
             border: var(--mynah-border-width) solid var(--mynah-color-border-default);


### PR DESCRIPTION
## Problem
Inline code blocks are not properly aligned with the texts in latest VSCode and JetBrains IDEs.

https://github.com/aws/mynah-ui/issues/101

## Solution
- Container box of inline code blocks are set to `inline-block` and vertical alignment is set to `middle`.
- Background and border pseudo selectors of the inline code blocks are realigned depending on the default line height.
    - While the `top:50%` property moves the box to the middle of the parent container, instead of using negative `margin` with a calculated value (px, rem, em etc.) we're using `transform: translateY(-50%)`. Because the percentage values inside transform uses the target container's sizes, for this, it means that it will move the background and the border if the inline code half to top.

<img width="469" alt="Screenshot 2024-09-04 at 11 45 00" src="https://github.com/user-attachments/assets/db2f90e4-a578-4a26-bd89-dbfb9678dbc5">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
