### PR TITLE
Dogusata/fix content left shift when width set to 0 temporarily

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.15.9",
+  "version": "4.15.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.15.9",
+      "version": "4.15.10",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.15.9",
+  "version": "4.15.10",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/helper/dom.ts
+++ b/src/helper/dom.ts
@@ -80,6 +80,7 @@ export class DomBuilder {
   private constructor (rootSelector: string) {
     this.root = DS(rootSelector)[0] as ExtendedHTMLElement;
     this.extendDomFunctionality(this.root);
+    this.root.addClass('mynah-ui-root');
     this.rootFocus = this.root.matches(':focus') ?? false;
     this.attachRootFocusListeners();
   }

--- a/src/styles/components/_main-container.scss
+++ b/src/styles/components/_main-container.scss
@@ -2,7 +2,8 @@
     display: flex;
     flex-flow: column nowrap;
     margin: 0 auto;
-    width: 100%;
+    width: inherit;
+    min-width: inherit;
     max-width: var(--mynah-max-width);
     box-sizing: border-box;
     height: 100%;
@@ -16,6 +17,12 @@
     > .mynah-ui-tab-contents-wrapper {
         flex: 1;
         position: relative;
+        width: inherit;
+        min-width: inherit;
+        max-width: inherit;
+        overflow: hidden;
+        display: flex;
+        flex-flow: column nowrap;
         &:first-child {
             > .mynah-chat-wrapper {
                 display: flex;

--- a/src/styles/components/_main-container.scss
+++ b/src/styles/components/_main-container.scss
@@ -1,4 +1,11 @@
+body.mynah-ui-root {
+    min-width: 100vw;
+    min-height: 100vh;
+}
+
 #mynah-wrapper {
+    container-type: size;
+    container-name: mynah-wrapper;
     display: flex;
     flex-flow: column nowrap;
     margin: 0 auto;
@@ -14,15 +21,20 @@
     background-color: var(--mynah-color-bg);
     color: var(--mynah-color-text-default);
 
+    > .mynah-no-tabs-wrapper:not(.hidden) {
+        & + .mynah-ui-tab-contents-wrapper {
+            display: none;
+        }
+    }
     > .mynah-ui-tab-contents-wrapper {
-        flex: 1;
         position: relative;
         width: inherit;
         min-width: inherit;
         max-width: inherit;
-        overflow: hidden;
-        display: flex;
-        flex-flow: column nowrap;
+        display: block;
+        height: inherit;
+        flex: 1;
+
         &:first-child {
             > .mynah-chat-wrapper {
                 display: flex;
@@ -48,5 +60,12 @@
 
     *:focus {
         outline: none;
+    }
+}
+
+@container mynah-wrapper (max-width: 0px) {
+    * {
+        display: none !important;
+        content-visibility: hidden !important;
     }
 }

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -247,6 +247,7 @@
     & + .mynah-chat-prompt-input-info {
         padding-top: 0;
         margin-top: calc(-1 * var(--mynah-sizing-2));
+        flex-basis: fit-content;
     }
 }
 

--- a/src/styles/components/chat/_chat-wrapper.scss
+++ b/src/styles/components/chat/_chat-wrapper.scss
@@ -14,6 +14,7 @@
     width: inherit;
     min-width: inherit;
     max-width: inherit;
+    height: 100%;
     flex: 1 0 100%;
     flex-flow: column nowrap;
     overflow: hidden;

--- a/src/styles/components/chat/_chat-wrapper.scss
+++ b/src/styles/components/chat/_chat-wrapper.scss
@@ -7,29 +7,30 @@
     align-items: flex-start;
 }
 .mynah-chat-wrapper {
-    transition: var(--mynah-bottom-panel-transition);
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: auto;
-    height: auto;
+    // This allows us to recalculate depending on the screen width went to 0 and reverted back (VSCode panel close/open)
+    transition: all 10ms 10ms linear;
+
+    position: relative;
+    width: inherit;
+    min-width: inherit;
+    max-width: inherit;
+    flex: 1 0 100%;
     flex-flow: column nowrap;
     overflow: hidden;
     justify-content: space-around;
     align-items: stretch;
     display: none;
-    > div[class^="mynah-chat"] {
-        width: 100%;
-        max-width: 100%;
+    > div[class^='mynah-chat'] {
+        width: inherit;
+        min-width: inherit;
+        max-width: inherit;
         box-sizing: border-box;
         padding-left: var(--mynah-sizing-4);
         padding-right: var(--mynah-sizing-4);
     }
     &:after {
         transition: var(--mynah-very-short-transition);
-        content: "";
+        content: '';
         position: absolute;
         top: 0;
         right: 0;
@@ -45,16 +46,16 @@
         transform-origin: center center;
     }
 
-    @import "chat-items-container";
-    @import "chat-overflowing-intermediate-block";
-    @import "chat-prompt-wrapper";
+    @import 'chat-items-container';
+    @import 'chat-overflowing-intermediate-block';
+    @import 'chat-prompt-wrapper';
 }
 
 .mynah-chat-items-container,
 .mynah-chat-prompt-input-sticky-card {
-    @import "chat-item-card";
+    @import 'chat-item-card';
 }
 
-@import "chat-command-selector";
-@import "chat-item-tree-view";
-@import "chat-prompt-attachment";
+@import 'chat-command-selector';
+@import 'chat-item-tree-view';
+@import 'chat-prompt-attachment';


### PR DESCRIPTION
## Problem
This PR resolves two issues:

### 1. Shifted chat contents
When you close and reopen Q panel, the contents of the active Q tab shifts to left and exceeds the left edge of the panel.

#### Reproduction
- Open Q panel in VSCode
- Type a query and hit enter
- Close the Q panel
- Wait until the response stream ends (you can check the output/Amazon Q to understand if the stream is finished)
- Open the panel back
<img width="542" alt="image" src="https://github.com/user-attachments/assets/8b1210c8-52bf-4c22-9da3-cd86d3cc01ef">


### [2. Tooltips remain on screen](https://github.com/aws/aws-toolkit-vscode/issues/5535)
When you suddenly close the Q panel while a tooltip/link preview is active and visible, when you open it back it remains on screen.

#### Reproduction
- Open Q panel in VSCode
- Get an answer with a related link on the footer of the card
- Hover to one of the links to preview show up
- User your keystroke to close the Q panel (for example if you're on mac and using the Q panel on right side panel use cmd+option+b to close/open it)
- Open the panel back
- Link preview remains on screen.
![image](https://github.com/user-attachments/assets/249782c5-5511-49de-857a-c8273eb12ac6)


## Solution!
The left shift issue is caused by the width value of the html/body/main-wrapper when the Q panel is closed on VSCode since VSCode make the extensions invisible by also setting their size to 0. When the panel opens back again, the mis-calculation of the size causes the contents (mainly on flex boxes) shift to left. So we need to ensure that both body and the main wrapper has a measured width (px, em, rem, vw etc.). In addition to that, we need to make it recalculated with the width change on main wrapper.
- Added `min-width` and `min-height` to the `body` if it is the `root` wrapper for mynah-ui
- Added a delay 10ms animator to the main wrapper to avoid immediate calculation and misplacement
- Added inheritance to the inner containers for the width and height values to follow the `root` wrapper sizing
- Converted unnecessary `flexbox` to `block`.
- Added `@container` check to turn everything's visibility off when the width is 0 (which will trigger a proper re-render when the width comes back)

For the remaining preview tooltips, when the panel is suddenly closed, the expected `mouseleave` and `mouseout` events are not being fired. Since we're also handling the element visibility with @container check now, it also removes the remaining preview tooltips as well. Which cannot be reappear unless the user hovers to the same thing again.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
