### PR TITLE
Add user intent to on code block action clicked event

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -428,11 +428,12 @@ export class MynahUI {
     });
 
     MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.CODE_BLOCK_ACTION, (data) => {
-      // TODO needs to be deprecated and followed through onCodeBlockActionClicked
       if (data.actionId === 'insert-to-cursor') {
-        this.props.onCodeInsertToCursorPosition?.(
+        this.props.onCodeBlockActionClicked?.(
           MynahUITabsStore.getInstance().getSelectedTabId(),
           data.messageId,
+          data.actionId,
+          data.data,
           data.text,
           data.type,
           data.referenceTrackerInformation,
@@ -441,12 +442,13 @@ export class MynahUI {
           data.totalCodeBlocks,
         );
       }
-      // TODO needs to be deprecated and followed through onCodeBlockActionClicked
       if (data.actionId === 'copy') {
         copyToClipboard(data.text, (): void => {
-          this.props.onCopyCodeToClipboard?.(
+          this.props.onCodeBlockActionClicked?.(
             MynahUITabsStore.getInstance().getSelectedTabId(),
             data.messageId,
+            data.actionId,
+            data.data,
             data.text,
             data.type,
             data.referenceTrackerInformation,


### PR DESCRIPTION
## Problem
UTG (Unit test generation) team is trying to gather metrics about unit test generation acceptance rates

https://quip-amazon.com/JIsUA8suEUaT/Add-UTG-metrics-to-IDE-plugins-and-RTS

## Solution

We're sending the user intent from the action id upon a code blocked action clicked event, and then capturing how often users interact directly with generated test code

## Testing
npm run test -> all tests passed

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
