### PR TITLE
fix content exceeds from bottom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/mynah-ui",
-  "version": "4.15.10",
+  "version": "4.15.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/mynah-ui",
-      "version": "4.15.10",
+      "version": "4.15.11",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/mynah-ui",
   "displayName": "AWS Mynah UI",
-  "version": "4.15.10",
+  "version": "4.15.11",
   "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
   "publisher": "Amazon Web Services",
   "license": "Apache License 2.0",

--- a/src/styles/components/chat/_chat-items-container.scss
+++ b/src/styles/components/chat/_chat-items-container.scss
@@ -1,7 +1,7 @@
 > .mynah-chat-items-container {
     position: relative;
     display: flex;
-    flex: 1 1 0%;
+    flex: 1 1 0;
     overflow-x: hidden;
     overflow-y: auto;
     flex-flow: column-reverse nowrap;


### PR DESCRIPTION
## Problem
Footer content exceeds from the bottom if the content block has a scroll (footer text not visible)
<img width="644" alt="image" src="https://github.com/user-attachments/assets/2302b676-bfbb-4e2f-8dc4-9739491be076">

## Solution
Fixed flexbox basis

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
