### PR TITLE
added getSelector helper function to easily get selectors with their …

### DIFF
--- a/ui-tests/__test__/flows/click-followup.ts
+++ b/ui-tests/__test__/flows/click-followup.ts
@@ -1,16 +1,16 @@
 import { Page } from 'playwright/test';
-import { waitForTransitionEnd } from '../helpers';
+import { getSelector, waitForTransitionEnd } from '../helpers';
 import testIds from '../../../src/helper/test-ids';
 
 export const clickToFollowup = async (page: Page): Promise<void> => {
-  const followupMessageSelector = `[${testIds.selector}="${testIds.chatItem.type.answer}"][messageid="mynah-ui-test-followup"]`;
+  const followupMessageSelector = `${getSelector(testIds.chatItem.type.answer)}[messageid="mynah-ui-test-followup"]`;
   await page.waitForSelector(followupMessageSelector);
   await waitForTransitionEnd(page, followupMessageSelector);
 
-  await page.locator(`${followupMessageSelector} [${testIds.selector}="${testIds.chatItem.chatItemFollowup.optionButton}"]:nth-child(1)`).click();
+  await page.locator(`${followupMessageSelector} ${getSelector(testIds.chatItem.chatItemFollowup.optionButton)}:nth-child(1)`).click();
   await page.mouse.move(0, 0);
 
-  await page.waitForSelector(`[${testIds.selector}="${testIds.chat.wrapper}"]:not(.loading)`);
+  await page.waitForSelector(`${getSelector(testIds.chat.wrapper)}:not(.loading)`);
   await page.waitForSelector(followupMessageSelector);
   await waitForTransitionEnd(page, followupMessageSelector);
 

--- a/ui-tests/__test__/flows/close-tab.ts
+++ b/ui-tests/__test__/flows/close-tab.ts
@@ -1,8 +1,9 @@
 import { Page } from 'playwright/test';
 import testIds from '../../../src/helper/test-ids';
+import { getSelector } from '../helpers';
 
 export const closeTab = async (page: Page): Promise<void> => {
-  await page.locator(`[${testIds.selector}="${testIds.tabBar.tabOptionWrapper}"]:nth-child(1) [${testIds.selector}="${testIds.tabBar.tabOptionCloseButton}"]`).click();
+  await page.locator(`${getSelector(testIds.tabBar.tabOptionWrapper)}:nth-child(1) ${getSelector(testIds.tabBar.tabOptionCloseButton)}`).click();
 
   expect(await page.screenshot()).toMatchImageSnapshot();
 };

--- a/ui-tests/__test__/flows/init-render.ts
+++ b/ui-tests/__test__/flows/init-render.ts
@@ -1,9 +1,9 @@
 import { Page } from 'playwright/test';
-import { waitForTransitionEnd } from '../helpers';
+import { getSelector, waitForTransitionEnd } from '../helpers';
 import testIds from '../../../src/helper/test-ids';
 
 export const initRender = async (page: Page): Promise<void> => {
-  const welcomeCardSelector = `[${testIds.selector}="${testIds.chatItem.type.answer}"]`;
+  const welcomeCardSelector = `${getSelector(testIds.chatItem.type.answer)}`;
   const welcomeCard = await page.waitForSelector(welcomeCardSelector);
   await waitForTransitionEnd(page, welcomeCardSelector);
   

--- a/ui-tests/__test__/flows/open-new-tab.ts
+++ b/ui-tests/__test__/flows/open-new-tab.ts
@@ -1,11 +1,11 @@
 import { Page } from 'playwright';
-import { waitForTransitionEnd } from '../helpers';
+import { getSelector, waitForTransitionEnd } from '../helpers';
 import testIds from '../../../src/helper/test-ids';
 
 export const openNewTab = async (page: Page): Promise<void> => {
   // Open new tab
-  await page.locator(`[${testIds.selector}="${testIds.tabBar.tabAddButton}"]`).click();
-  const welcomeCardSelector = `[${testIds.selector}="${testIds.chatItem.type.answer}"]`;
+  await page.locator(`${getSelector(testIds.tabBar.tabAddButton)}`).click();
+  const welcomeCardSelector = `${getSelector(testIds.chatItem.type.answer)}`;
   const welcomeCard = await page.waitForSelector(welcomeCardSelector);
   await waitForTransitionEnd(page, welcomeCardSelector);
   

--- a/ui-tests/__test__/flows/render-user-prompt.ts
+++ b/ui-tests/__test__/flows/render-user-prompt.ts
@@ -1,12 +1,12 @@
 import { Page } from 'playwright/test';
-import { waitForTransitionEnd } from '../helpers';
+import { getSelector, waitForTransitionEnd } from '../helpers';
 import testIds from '../../../src/helper/test-ids';
 
 export const renderUserPrompt = async (page: Page): Promise<void> => {
-  await page.locator(`[${testIds.selector}="${testIds.prompt.input}"]`).fill('This is a user Prompt');
-  await page.locator(`[${testIds.selector}="${testIds.prompt.send}"]`).click();
+  await page.locator(`${getSelector(testIds.prompt.input)}`).fill('This is a user Prompt');
+  await page.locator(`${getSelector(testIds.prompt.send)}`).click();
 
-  const userCardSelector = `[${testIds.selector}="${testIds.chatItem.type.prompt}"]`;
+  const userCardSelector = `${getSelector(testIds.chatItem.type.prompt)}`;
   const userCard = await page.waitForSelector(userCardSelector);
   await waitForTransitionEnd(page, userCardSelector);
 

--- a/ui-tests/__test__/helpers.ts
+++ b/ui-tests/__test__/helpers.ts
@@ -1,7 +1,5 @@
 import { ElementHandle, Page } from 'playwright/test';
-import fs from 'fs';
-
-export const TEMP_SCREENSHOT_PATH = './temp-snapshot.png';
+import testIds from '../../src/helper/test-ids';
 
 export async function waitForTransitionEnd (page: Page, element: string): Promise<void> {
   if(typeof element === 'string'){
@@ -25,4 +23,8 @@ export async function waitForTransitionEnd (page: Page, element: string): Promis
       });
     }, element);
   }
+}
+
+export function getSelector(selector: string):string {
+  return `[${testIds.selector}="${selector}"]`;
 }


### PR DESCRIPTION
Added `getSelector` helper function which accepts the testId and automatically returns the attribute css selector for that element. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
