### PR TITLE
Centered footer text

### DIFF
--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -268,6 +268,7 @@
 > .mynah-chat-prompt-input-info {
     display: flex;
     flex-flow: row nowrap;
+    justify-content: center;
     box-sizing: border-box;
     overflow: hidden;
     padding: var(--mynah-sizing-4);


### PR DESCRIPTION
## Problem
The footer text of the chat dialogue should be centered. 

## Solution
A simple CSS change to accommodate the centering through flex.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
