### PR TITLE
feat: added public method for tab focus from agent

### DIFF
--- a/example/dev.js
+++ b/example/dev.js
@@ -1,2 +1,12 @@
-import open from 'open';
-await open('./dist/index.html');
+// Dynamic import handling
+const openFile = async () => {
+    try {
+        // Use dynamic import to load the ES module
+        const open = (await import('open')).default;
+        await open('./dist/index.html');
+    } catch (err) {
+        console.error('Error opening file:', err);
+    }
+};
+
+openFile();

--- a/src/main.ts
+++ b/src/main.ts
@@ -679,6 +679,23 @@ export class MynahUI {
   };
 
   /**
+   * Selects a tab with the given generated ID.
+   * @param tabId - The ID of the tab to select.
+   * @returns void
+   * This function is used to select a tab with the given generated ID.
+   * If the tab does not exist, it will not select any tab.
+   * This function is useful when you want to select a tab with a known ID, yet without user interaction.
+   * for example, in response to a message from the chat, which produces a notification and the tab currently selected is not the one that the notification is related to.
+   * @example
+   */
+  public setFocusTab = (tabId: string): void => {
+    if (MynahUITabsStore.getInstance().getTab(tabId) !== null) {
+      const eventId = this.getUserEventId();
+      this.selectTab(tabId, eventId);
+    }
+  };
+
+  /**
    * If exists, close the given tab
    * @param tabId Tab ID to switch to
    * @param eventId last action's user event ID passed from an event binded to mynahUI.


### PR DESCRIPTION
## Problem 1

> [!WARNING]  
> `npm run dev` && husky break things for module import

```
(node:66958) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/../../example/dev.js:1
import open from 'open';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at internalCompileFunction (node:internal/vm:76:18)
    at wrapSafe (node:internal/modules/cjs/loader:1283:20)
    at Module._compile (node:internal/modules/cjs/loader:1328:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Module._load (node:internal/modules/cjs/loader:1019:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12)
    at node:internal/main/run_main_module:28:49
```


## Solution 1

* Add dynamic import, easy clean up

```
// Dynamic import handling
const openFile = async () => {
    try {
        // Use dynamic import to load the ES module
        const open = (await import('open')).default;
        await open('./dist/index.html');
    } catch (err) {
        console.error('Error opening file:', err);
    }
};

openFile();
```

## Problem 2

Using mynah-ui in vs code extension there is not currently available a good way to have a notification callback command select a tab if many are open and the responding message is not in the currently focused tab

If i have many tabs in the mynah chat in vs code open, and one that receives a response that generates a vs code notification, i would like to be able to click the notification and refocus on said tab

## Solution 2

* Add `setFocusTab` as a public member of mynah class that can deterministically set focus on the specific tab without having an eventId (it can generate one) retaining eventId as private generated id

## Fun test for Solution 2

* Fork this branch
* `npm run dev`
* go see this [gist](https://gist.github.com/32teeth/dbcb43b8a0bc906ef232092c68f6f097)
* copy paste into dev console
* run the console script

![setFocusTab](https://github.com/user-attachments/assets/bb80910b-ced0-4ee5-a351-6bdc1d9a3259)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
