### PR TITLE
120: send button shifts out of view

### DIFF
--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -54,6 +54,7 @@
                 width: 100%;
                 position: relative;
                 align-self: center;
+                overflow: hidden;
 
                 > .mynah-chat-prompt-input {
                     font-family: var(--mynah-font-family);

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -68,9 +68,8 @@
                     max-height: 20vh;
                     line-height: var(--mynah-line-height);
                     white-space: pre-wrap;
+                    word-break: normal;
                     overflow-wrap: break-word;
-                    word-break: break-all;
-                    word-wrap: break-word;
 
                     &:placeholder-shown {
                         text-overflow: ellipsis;

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -68,8 +68,9 @@
                     max-height: 20vh;
                     line-height: var(--mynah-line-height);
                     white-space: pre-wrap;
-                    word-break: normal;
                     overflow-wrap: break-word;
+                    word-break: break-all;
+                    word-wrap: break-word;
 
                     &:placeholder-shown {
                         text-overflow: ellipsis;


### PR DESCRIPTION
## Problem
When there is a long text without and line breaks or spaces, send button shifts out from the right edge.

## Solution
Overflow of the text input set to hidden to prevent overflowing.

## License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
