### PR TITLE
Footer text now wraps instead of overflowing on smaller windows

### DIFF
--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -261,6 +261,7 @@
     box-sizing: border-box;
     overflow: hidden;
     padding: var(--mynah-sizing-4);
+    text-align: center;
 
     &,
     & * {
@@ -277,5 +278,7 @@
         margin-block-end: 0;
         margin-top: 0;
         margin-bottom: 0;
+        max-width: 100%;
+        box-sizing: border-box;
     }
 }


### PR DESCRIPTION
## Problem
Footer text is overflowing instead of wrapping

## Solution
Add max width 100% to children of the footer text wrapper.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
