### PR TITLE
#127: Inlined code elements wrap onto new lines, normal code elements will not

### DIFF
--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -107,6 +107,11 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             display: inline-block;
             position: relative;
             vertical-align: middle;
+            white-space: pre-wrap;
+
+            & * {
+                white-space: pre-wrap;
+            }
         }
 
         &:after,
@@ -114,7 +119,7 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             content: '';
             position: absolute;
             top: 50%;
-            height: calc(3px + var(--mynah-line-height));
+            height: 100%;
             left: -3px;
             width: calc(100% + 6px);
             border-radius: var(--mynah-input-radius);


### PR DESCRIPTION
## Problem
Inline code elements formatted in a sent prompt message can overflow out of the visible chat window by being too long to fit. (issue #127)

## Solution
Set whitespace to wrap in inline elements when overflowing.

## License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
