### PR TITLE
#130: Code blocks now wrap text on screens narrower than 300px

### DIFF
--- a/src/styles/_scss-variables.scss
+++ b/src/styles/_scss-variables.scss
@@ -14,3 +14,5 @@ $mynah-padding-sizes: (
     'medium': 3,
     'large': 5,
 );
+
+$mynah-code-blocks-wrap-under: 300px;

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -150,6 +150,10 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             filter: brightness(0.95);
             white-space: pre;
             background-color: inherit;
+
+            @media (max-width: 300px) {
+                white-space: pre-wrap;
+            }
         }
 
         > code,
@@ -161,6 +165,11 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             word-wrap: normal;
             tab-size: 4;
             hyphens: none;
+
+            @media (max-width: 300px) {
+                white-space: pre-wrap;
+                word-wrap: break-word;
+            }
         }
 
         > code::selection,

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -1,3 +1,5 @@
+@import '../scss-variables';
+
 pre.diff-highlight > code .token.deleted:not(.prefix),
 pre > code.diff-highlight .token.deleted:not(.prefix) {
     background-color: rgba(255, 0, 0, 0.1);
@@ -151,7 +153,7 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             white-space: pre;
             background-color: inherit;
 
-            @media (max-width: 300px) {
+            @media (max-width: $mynah-code-blocks-wrap-under) {
                 white-space: pre-wrap;
             }
         }
@@ -166,7 +168,7 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             tab-size: 4;
             hyphens: none;
 
-            @media (max-width: 300px) {
+            @media (max-width: $mynah-code-blocks-wrap-under) {
                 white-space: pre-wrap;
                 word-wrap: break-word;
             }


### PR DESCRIPTION
## Problem
For readability of the code blocks in narrow screen conditions, it is better to wrap the code block texts since horizontal scrolling will cause too much movement.

## Solution
Code blocks now take on a `white-space` of `pre-wrap` on screens narrower than 300px, ensuring the code is wrapped instead of overflowing with a scroll bar.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
