### PR TITLE
Fixed inline code wrapping, previous fix did not cover full issue

### DIFF
--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -106,10 +106,12 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             display: inline-block;
             position: relative;
             vertical-align: middle;
-            white-space: pre-wrap;
+            white-space: normal;
+            word-wrap: break-word;
+            max-width: 100%;
 
             & * {
-                white-space: pre-wrap;
+                white-space: normal;
             }
         }
 


### PR DESCRIPTION
## Problem
Inline code snippets can sometime overflow out of the screen, without wrapping / scrolling.

## Solution
The content of inline code snippets now properly wraps onto new lines.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
