### PR TITLE
fix: module import #135

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,23 @@ Mynah UI operates independently of any framework or UI library, enabling seamles
 * [Live Demo](https://aws.github.io/mynah-ui/)
 * [API Docs](https://aws.github.io/mynah-ui/api-doc/index.html)
 
+
 ### Setup, configuration and use
 
->[!TIP]
-> Local environment quick start
- ```console
- git clone git@github.com:aws/mynah-ui.git
- cd mynah-ui && npm install
- cd example && npm install
+To set up your local development environment quickly, run the following command:
+
+```bash
+npm run dev
 ```
-Now run `npm watch` in both the `mynah-ui` and the `example` directories, and open `mynah-ui/example/dist/index.html` in a browser of choice.
+
+This command will:
+1. **Clean**: Remove existing `dist` and `node_modules` directories to ensure you're working with a fresh environment.
+2. **Install**: Reinstall all necessary dependencies for both the main project and the example project.
+3. **Build**: Compile the project using Webpack in production mode.
+4. **Start Example**: Install dependencies and build the example project, then start the development server with `watch` mode enabled. The project will be served on `localhost:9000` using `live-server`.
+5. **Watch**: Start the main project in `watch` mode.
+After running this command, any changes you make will automatically rebuild and refresh your development environment, allowing you to work seamlessly.
+
 
 #### Guides and documentation
 Please refer to the following guides:

--- a/example/dev.js
+++ b/example/dev.js
@@ -1,2 +1,11 @@
-import open from 'open';
-await open('./dist/index.html');
+const openFile = async () => {
+    try {
+        // Use dynamic import to load the ES module
+        const open = (await import('open')).default;
+        await open('./dist/index.html');
+    } catch (err) {
+        console.error('Error opening file:', err);
+    }
+};
+
+openFile();

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
         "packdemo": "cd ./example && npm run pack",
         "watch": "webpack --config webpack.config.js --mode development --watch",
         "watch:example": "cd ./example && npm run watch",
-        "start:example": "cd ./example && npm install && npm run build && npm run dev",
+        "watch:web": "run-p watch watch:example serve:example",
+        "serve:example": "live-server --port=9000 example/dist",
+        "start:example": "cd ./example && npm install && npm run build && cd .. && npm run watch:web",
         "dev": "npm run clean && npm install && npm run build && npm run start:example",
         "lint-fix": "npx eslint \"./**\" --fix",
         "lint": "npx eslint \"./**\"",
@@ -29,7 +31,7 @@
         "tests:e2e": "cd ./ui-tests && npm install && npm run prepare && npm run e2e",
         "api-docs": "npx typedoc src/main.ts --out ./api-docs",
         "api-doc-deploy": "npx typedoc src/main.ts --out ./example/dist/api-doc",
-        "postinstall": "node postinstall.js",
+        "postinstall": "npm install -g live-server && node postinstall.js",
         "prepare": "npx husky"
     },
     "dependencies": {


### PR DESCRIPTION
## Problem

`npm run dev` && husky break things for module import

## Solution

> [!WARNING]  
> `npm run dev` && husky break things for module import

```
(node:66958) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/../../example/dev.js:1
import open from 'open';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at internalCompileFunction (node:internal/vm:76:18)
    at wrapSafe (node:internal/modules/cjs/loader:1283:20)
    at Module._compile (node:internal/modules/cjs/loader:1328:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Module._load (node:internal/modules/cjs/loader:1019:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12)
    at node:internal/main/run_main_module:28:49
```

> [!NOTE]  
> Add dynamic import, easy clean up

```
// Dynamic import handling
const openFile = async () => {
    try {
        // Use dynamic import to load the ES module
        const open = (await import('open')).default;
        await open('./dist/index.html');
    } catch (err) {
        console.error('Error opening file:', err);
    }
};

openFile();
```
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
