### PR TITLE
fix: add data-label property to buttons

### DIFF
--- a/src/components/__test__/button.spec.ts
+++ b/src/components/__test__/button.spec.ts
@@ -79,4 +79,20 @@ describe('button', () => {
     testButtonElement.dispatchEvent(new Event('mouseenter'));
     expect(mockMouseOverHandler).toHaveBeenCalledTimes(1);
   });
+
+  it('data-label attribute', () => {
+    const mockOnClickHandler = jest.fn();
+    const testButton = new Button({
+      label: 'Test button',
+      onClick: mockOnClickHandler,
+    });
+    const testButton2 = new Button({
+      onClick: mockOnClickHandler,
+    });
+
+    expect(testButton.render.getAttribute('data-label')).toBe('Test button');
+    expect(testButton2.render.getAttribute('data-label')).toBeNull();
+    testButton.updateLabel('Updated label');
+    expect(testButton.render.getAttribute('data-label')).toBe('Updated label');
+  });
 });

--- a/src/components/button.ts
+++ b/src/components/button.ts
@@ -63,6 +63,7 @@ class ButtonInternal extends ButtonAbstract {
       testId: props.testId,
       attributes: {
         ...(props.disabled === true ? { disabled: 'disabled' } : {}),
+        ...(Boolean(props.label) && typeof props.label === 'string' ? { 'data-label': props.label } : {}),
         tabindex: '0',
         ...props.attributes,
       },
@@ -152,6 +153,9 @@ class ButtonInternal extends ButtonAbstract {
     (this.render.querySelector('.mynah-button-label') as ExtendedHTMLElement).replaceWith(
       DomBuilder.getInstance().build(this.getButtonLabelDomBuilderObject(label)[0])
     );
+    if (typeof label === 'string') {
+      this.render.setAttribute('data-label', label);
+    }
   };
 
   public readonly setEnabled = (enabled: boolean): void => {


### PR DESCRIPTION
Add data-label attributes DOM. These data attributes can then be used by IDEs to define custom CSS, based on the button text.

<img width="1271" alt="Screenshot 2024-10-16 at 3 13 42 PM" src="https://github.com/user-attachments/assets/3ffd8f4a-a44f-4902-ad6a-60f3dab4c5ee">
<img width="993" alt="Screenshot 2024-10-16 at 3 14 25 PM" src="https://github.com/user-attachments/assets/5443bf62-4ade-4b07-a3c5-930962e58b8c">


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
