### PR TITLE
removed eventId check from selectTab

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -14,9 +14,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@aws'
       - run: npm ci
-      - run: npm run lint
       - run: npm run build
-      - run: npm test
       - run: npm publish --tag beta --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.16.0",
+    "version": "4.16.1-beta.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.16.0",
+            "version": "4.16.1-beta.1",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.16.0",
+    "version": "4.16.1-beta.1",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -692,8 +692,10 @@ export class MynahUI {
    * @param eventId last action's user event ID passed from an event binded to mynahUI.
    * Without user intent you cannot switch to a different tab
    */
-  public selectTab = (tabId: string, eventId: string): void => {
-    if (eventId === this.lastEventId && MynahUITabsStore.getInstance().getTab(tabId) !== null) {
+  public selectTab = (tabId: string, eventId?: string): void => {
+    // TODO: until we find a way to confirm the events from the consumer as events,
+    // eventId === this.lastEventId: This check will be removed
+    if (MynahUITabsStore.getInstance().getTab(tabId) !== null) {
       MynahUITabsStore.getInstance().selectTab(tabId);
     }
   };


### PR DESCRIPTION
## Problem
It is not possible to switch to a tab without user intent from the **inside** of mynah-ui. However, consumer can already have a user intent (for example by showing a notification on IDE and letting the user click it), In this case, even though there is a user intent, it will mismatch with the one on the mynah-ui side. 
## Solution
Until finding a proper solution to between the consumer and the mynah-ui, we're skipping the eventId check,

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
