### PR TITLE
feature: added publish configurations for NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "main": "./dist/main.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/mynah-ui"
+        "url": "git+https://github.com/aws/mynah-ui.git"
+    },
+    "publishConfig": {
+        "registry": "https://registry.npmjs.com/"
     },
     "scripts": {
         "clean": "npm run clean:dist && npm run clean:node",
@@ -30,7 +33,10 @@
         "api-docs": "npx typedoc src/main.ts --out ./api-docs",
         "api-doc-deploy": "npx typedoc src/main.ts --out ./example/dist/api-doc",
         "postinstall": "node postinstall.js",
-        "prepare": "npx husky"
+        "prepare": "npx husky",
+        "publish:npm": "npm publish --registry https://registry.npmjs.org/",
+        "publish:github": "npm publish --registry https://npm.pkg.github.com/",
+        "publish": "npm run publish:npm && npm run publish:github"
     },
     "dependencies": {
         "escape-html": "^1.0.3",


### PR DESCRIPTION
## Problem

## Solution

* added registry and `publish` script
* you can now run `npm run publish` and this will publish the npm to both 
  * https://registry.npmjs.org/
  * https://npm.pkg.github.com
  
> [!NOTE]
>  edit your local root `.npmrc` with the login tokens

```
registry=https://registry.npmjs.org/
@aws:registry=https://registry.npmjs.org/
//registry.npmjs.org/:_authToken=npm_********************
//npm.pkg.github.com/:_authToken=ghp_********************
```

> [!TIP]
> You can log in to the registries to get your tokens

```
npm login --registry=https://registry.npmjs.org/
npm login --registry=https://npm.pkg.github.com/
```

After this, you can simply run 
```
npm run publish
```

> [!IMPORTANT]
> The GitHub one will add this super duper awesome link to the right rail

<img width="300" alt="Screenshot 2024-10-17 at 12 19 49 PM" src="https://github.com/user-attachments/assets/b825c057-8c2f-4f4e-95f2-e2f1c2bca513">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
