### PR TITLE
fix: only re-focus after a response stream if the window is active

### DIFF
--- a/src/components/chat-item/prompt-input/prompt-text-input.ts
+++ b/src/components/chat-item/prompt-input/prompt-text-input.ts
@@ -115,7 +115,7 @@ export class PromptTextInput {
       } else {
         // Enable the input field and focus on it
         this.promptTextInput.removeAttribute('disabled');
-        if (Config.getInstance().config.autoFocus) {
+        if (Config.getInstance().config.autoFocus && document.hasFocus()) {
           this.promptTextInput.focus();
         }
       }


### PR DESCRIPTION
## Problem
In VSCode if you:
    - write a message in chat
    - focus somewhere else in the editor outside of chat
    - wait for the response stream to finish
it will automatically focus the chat prompt

## Solution
Only refocus the chat prompt if the document is currently focused

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
