### PR TITLE
Removed global liveserver install to fix postinstall script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.17.0",
+    "version": "4.17.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.17.0",
+            "version": "4.17.1",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.17.0",
+    "version": "4.17.1",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "tests:e2e": "cd ./ui-tests && npm install && npm run prepare && npm run e2e",
         "api-docs": "npx typedoc src/main.ts --out ./api-docs",
         "api-doc-deploy": "npx typedoc src/main.ts --out ./example/dist/api-doc",
-        "postinstall": "npm install -g live-server && node postinstall.js",
+        "postinstall": "node postinstall.js",
         "prepare": "npx husky"
     },
     "dependencies": {


### PR DESCRIPTION
## Problem
The global `npm install -g liveserver` installation on the `postinstall` script causes build issues for the AWS toolkit.

## Solution
Removed the global package install, requiring users to do a manual global installation of the `liveserver` package. Also, going to upgrade contribution / PR docs to confirm it being tested on VSCode and Jetbrains.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
