### PR TITLE
Improved scrollbar color

### DIFF
--- a/src/styles/_scrollbars.scss
+++ b/src/styles/_scrollbars.scss
@@ -1,4 +1,4 @@
 * {
     scrollbar-gutter: unset;
-    scrollbar-color: color-mix(in hsl, var(--mynah-color-text-default), hsl(0, 100%, 100%) 90%) transparent;
+    scrollbar-color: color-mix(in hsl, var(--mynah-card-bg-alternate), hsla(0, 0%, 100%, 0.2) 90%) transparent;
 }


### PR DESCRIPTION
## Problem
The styling of the scrollbar, especially the color and the width, don't match the other scrollbars in the VS Code interface.

## Solution
Scrollbar now uses the alternate card background color variable, with decreased opacity.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
