### PR TITLE
Fixed URL color visibility issues on some themes

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -17,6 +17,7 @@
     --mynah-color-text-strong: var(--vscode-input-foreground);
     --mynah-color-text-weak: var(--vscode-disabledForeground);
     --mynah-color-text-link: var(--vscode-textLink-foreground);
+    --mynah-color-text-link-alternate: var(--mynah-color-button-reverse);
     --mynah-color-text-input: var(--vscode-input-foreground);
 
     --mynah-color-bg: var(--vscode-sideBar-background);

--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -271,6 +271,10 @@
             > .mynah-card-body {
                 color: var(--mynah-color-text-alternate);
                 overflow-wrap: break-word;
+
+                a {
+                    color: var(--mynah-color-text-link-alternate);
+                }
             }
         }
         .mynah-chat-item-card-related-content > .mynah-card {


### PR DESCRIPTION
## Problem
URLs sent to chat by the user are barely visible in the VSCode light theme, which is used widely by developers, so for UX reasons this should be addressed.

## Solution
Use an alternate color for links sent in cards with type `prompt`.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
