### PR TITLE
Fix disappearing span tags inside code blocks

### DIFF
--- a/src/components/__test__/syntax-highlighter.spec.ts
+++ b/src/components/__test__/syntax-highlighter.spec.ts
@@ -5,7 +5,6 @@ describe('syntax-highlighter', () => {
     const testSyntaxHighlighter = new SyntaxHighlighter({
       codeStringWithMarkup: 'alert("hello");\n',
       language: 'js',
-      keepHighlights: true,
       block: true,
     });
 
@@ -18,7 +17,6 @@ describe('syntax-highlighter', () => {
     const testSyntaxHighlighter = new SyntaxHighlighter({
       codeStringWithMarkup: 'alert("hello");\n',
       language: 'typescript',
-      keepHighlights: true,
       codeBlockActions: {
         copy: {
           id: 'copy',

--- a/src/components/button.ts
+++ b/src/components/button.ts
@@ -12,6 +12,7 @@ import { Config } from '../helper/config';
 import { cancelEvent } from '../helper/events';
 import escapeHTML from 'escape-html';
 import '../styles/components/_button.scss';
+import unescapeHTML from 'unescape-html';
 
 const TOOLTIP_DELAY = 350;
 export interface ButtonProps {
@@ -106,7 +107,7 @@ class ButtonInternal extends ButtonAbstract {
       if (typeof label !== 'string') {
         return [ { type: 'span', classNames: [ 'mynah-button-label' ], children: [ label ] } ];
       } else {
-        return [ { type: 'span', classNames: [ 'mynah-button-label' ], innerHTML: marked.parseInline(escapeHTML(label)) as string } ];
+        return [ { type: 'span', classNames: [ 'mynah-button-label' ], innerHTML: marked.parseInline(unescapeHTML(escapeHTML(label))) as string } ];
       }
     }
     return [];

--- a/src/components/card/card-body.ts
+++ b/src/components/card/card-body.ts
@@ -136,7 +136,6 @@ export class CardBody {
         const highlighter = new SyntaxHighlighter({
           codeStringWithMarkup: unescapeHTML(codeString),
           language: snippetLanguage?.trim() !== '' ? snippetLanguage : '',
-          keepHighlights: true,
           codeBlockActions: !isBlockCode
             ? undefined
             : {

--- a/src/components/syntax-highlighter.ts
+++ b/src/components/syntax-highlighter.ts
@@ -43,10 +43,10 @@ import { Icon } from './icon';
 import { cancelEvent } from '../helper/events';
 import { highlightersWithTooltip } from './card/card-body';
 import escapeHTML from 'escape-html';
-import unescapeHTML from 'unescape-html';
 import '../styles/components/_syntax-highlighter.scss';
 import { copyToClipboard } from '../helper/chat-item';
 import testIds from '../helper/test-ids';
+import unescapeHTML from 'unescape-html';
 
 const IMPORTED_LANGS = [
   'markup',
@@ -98,32 +98,9 @@ const IMPORTED_LANGS = [
 ];
 const DEFAULT_LANG = 'clike';
 
-// they'll be used to replaced within the code, so making them unique is a must
-export const highlighters = {
-  start: {
-    markup: '<span class="amzn-mynah-search-result-highlight">',
-    textReplacement: '__mynahhighlighterstart__',
-  },
-  end: {
-    markup: '</span>',
-    textReplacement: '__mynahhighlighterend__',
-  },
-};
-export const ellipsis = {
-  start: {
-    markup: '<span class="amzn-mynah-search-result-ellipsis">',
-    textReplacement: '__mynahcodeellipsisstart__',
-  },
-  end: {
-    markup: '</span>',
-    textReplacement: '__mynahcodeellipsisend__',
-  },
-};
-
 export interface SyntaxHighlighterProps {
   codeStringWithMarkup: string;
   language?: string;
-  keepHighlights?: boolean;
   showLineNumbers?: boolean;
   block?: boolean;
   startingLineNumber?: number;
@@ -141,17 +118,8 @@ export class SyntaxHighlighter {
   constructor (props: SyntaxHighlighterProps) {
     this.props = props;
 
-    let codeMarkup = unescapeHTML(props.codeStringWithMarkup);
-    // Replacing the incoming markups with keyword matching static texts
-    if (props.keepHighlights === true) {
-      codeMarkup = codeMarkup
-        .replace(new RegExp(highlighters.start.markup, 'g'), highlighters.start.textReplacement)
-        .replace(new RegExp(highlighters.end.markup, 'g'), highlighters.end.textReplacement)
-        .replace(new RegExp(ellipsis.start.markup, 'g'), ellipsis.start.textReplacement)
-        .replace(new RegExp(ellipsis.end.markup, 'g'), ellipsis.end.textReplacement);
-    }
-
-    let escapedCodeBlock = escapeHTML(codeMarkup);
+    // To ensure we are not leaving anything unescaped before escaping i.e to prevent double escaping
+    let escapedCodeBlock = escapeHTML(unescapeHTML(props.codeStringWithMarkup));
 
     // Convert reference tracker escaped markups back to original incoming from the parent
     escapedCodeBlock = escapedCodeBlock
@@ -186,15 +154,6 @@ export class SyntaxHighlighter {
       }
     });
     highlightElement(preElement);
-
-    // replacing back the keyword matchings for incoming highlights to markup for highlighting code
-    if (props.keepHighlights === true) {
-      preElement.innerHTML = preElement.innerHTML
-        .replace(new RegExp(highlighters.start.textReplacement, 'g'), highlighters.start.markup)
-        .replace(new RegExp(highlighters.end.textReplacement, 'g'), highlighters.end.markup)
-        .replace(new RegExp(ellipsis.start.textReplacement, 'g'), ellipsis.start.markup)
-        .replace(new RegExp(ellipsis.end.textReplacement, 'g'), ellipsis.end.markup);
-    }
 
     if (props.codeBlockActions != null) {
       Object.keys(props.codeBlockActions).forEach((actionId: string) => {

--- a/src/styles/components/card/_card-body.scss
+++ b/src/styles/components/card/_card-body.scss
@@ -170,35 +170,5 @@
             color: inherit;
             cursor: help;
         }
-
-        .amzn-mynah-search-result-highlight {
-            background-color: var(--mynah-color-highlight);
-            color: var(--mynah-color-highlight-text);
-        }
-
-        .amzn-mynah-search-result-ellipsis {
-            display: inline-block;
-            position: relative;
-            padding-left: var(--mynah-sizing-2);
-            margin-top: var(--mynah-sizing-1);
-            margin-bottom: var(--mynah-sizing-1);
-            font-size: calc(1em + var(--mynah-sizing-1)) !important;
-            user-select: none;
-            cursor: default;
-            height: var(--mynah-sizing-7);
-
-            &:before {
-                pointer-events: none;
-                content: '';
-                width: calc(1em + var(--mynah-sizing-2));
-                height: calc(1em + var(--mynah-sizing-2));
-                position: absolute;
-                left: 0;
-                top: 0;
-                background-color: currentColor;
-                opacity: 0.1;
-                border-radius: var(--mynah-sizing-1);
-            }
-        }
     }
 }

--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -194,10 +194,6 @@
                 border-radius: 0;
                 box-shadow: none;
             }
-            .amzn-mynah-search-result-highlight {
-                background-color: inherit;
-                color: inherit;
-            }
         }
         &:not(.expanded) {
             > .mynah-chat-item-card-related-content-item {


### PR DESCRIPTION
## Problem

The issue was reported in: https://github.com/aws/aws-toolkit-vscode/issues/5732

When there is a closing `span` tag inside a code block or inline code, it currently disappears and is not rendered. This is caused by old code in mynah-ui that would do some pre-processing on the html contents and replace certain span elements before they were rendered. This causes any span tag to be replaced and removed before they are rendered and this leads to the bug described above

See for example how the following input is rendered currently:

````
```
<span> span inside a codeblock </span>
```

`<span> span inside inline code </span>`

`````
<img width="1053" alt="Screenshot 2024-11-07 at 11 20 56" src="https://github.com/user-attachments/assets/1519e9a4-08f8-4e41-81a5-0c5debd0a394">


## Solution

To remove the old `keepHighlights` functionality. 

See an example card body that correctly renders the span tags after the fix: 

<img width="364" alt="Screenshot 2024-11-07 at 11 24 00" src="https://github.com/user-attachments/assets/92646923-13c0-424a-a59d-984f907325b2">

And the test case from above with prompt input containing spans:
 
<img width="484" alt="Screenshot 2024-11-07 at 11 44 08" src="https://github.com/user-attachments/assets/8fae62b8-1a7b-4c24-b278-2a51a39b0833">

## Tests
- [x] I have tested this change on VSCode
- [x] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
