### PR TITLE
fixed file tree item title shrink

### DIFF
--- a/src/styles/components/chat/_chat-item-tree-view.scss
+++ b/src/styles/components/chat/_chat-item-tree-view.scss
@@ -242,10 +242,11 @@
                 max-width: 100%;
                 overflow: hidden;
                 z-index: 10;
-                flex-shrink: 0;
+                flex-shrink: 1;
 
-                > i {
+                > .mynah-ui-icon {
                     opacity: 0.75;
+                    flex-shrink: 0;
                 }
 
                 > span {


### PR DESCRIPTION
## Problem
When the text of a file is too long the actions are not visible and the icon shrinks down.

<img width="373" alt="Screenshot 2024-11-07 at 12 06 07" src="https://github.com/user-attachments/assets/da6ec01a-79d0-403d-8835-96d32e2a86ff">

## Solution
Flex shrink values properly adjusted.
<img width="371" alt="Screenshot 2024-11-07 at 12 05 45" src="https://github.com/user-attachments/assets/aa82d92a-87f3-4a7b-9f04-8d1cce219a12">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
