### PR TITLE
Updated PR runner to use MacOS-latest

### DIFF
--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -4,7 +4,7 @@ on:
     branches: [main, feature/*, fix/*]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/ui-tests/__test__/flows/welcome-mode.ts
+++ b/ui-tests/__test__/flows/welcome-mode.ts
@@ -63,10 +63,7 @@ export const welcomeMode = async (page: Page, skipScreenshots?: boolean): Promis
 
   if (skipScreenshots !== true) {
     // snap
-    // TODO: Reduced threshold because of the background image problem.
-    expect(await page.screenshot()).toMatchImageSnapshot({
-      failureThreshold: 0.75
-    });
+    expect(await page.screenshot()).toMatchImageSnapshot({});
   }
 
   await closeTab(page, false, true);


### PR DESCRIPTION
## Problem
The OS for the GitHub Action test runner currently runs Ubuntu, causing different results for E2E test runners compared to local dev environments.

## Solution
Use MacOS-latest as test runner OS.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
