### PR TITLE
Dogusata/fix file details and name unnecessary crop

### DIFF
--- a/src/components/chat-item/chat-item-tree-file.ts
+++ b/src/components/chat-item/chat-item-tree-file.ts
@@ -50,15 +50,26 @@ export class ChatItemTreeFile {
             });
           }
         },
-        ...(this.props.details?.description != null
-          ? {
-              mouseenter: (e: MouseEvent) => {
-                const tooltipText = marked(this.props.details?.description ?? '', { breaks: true }) as string;
-                this.showTooltip(tooltipText, OverlayVerticalDirection.CENTER, OverlayHorizontalDirection.TO_RIGHT);
-              },
-              mouseout: this.hideTooltip
+        mouseover: (e) => {
+          cancelEvent(e);
+          const textContentSpan: HTMLSpanElement | null = this.render.querySelector('.mynah-chat-item-tree-view-file-item-title-text');
+          let tooltipText;
+          if (textContentSpan != null && textContentSpan.offsetWidth < textContentSpan.scrollWidth) {
+            tooltipText = marked(this.props.fileName, { breaks: true }) as string;
+          }
+          if (this.props.details?.description != null) {
+            if (tooltipText != null) {
+              tooltipText += '\n\n';
+            } else {
+              tooltipText = '';
             }
-          : {})
+            tooltipText += marked(this.props.details?.description ?? '', { breaks: true }) as string;
+          }
+          if (tooltipText != null) {
+            this.showTooltip(tooltipText);
+          }
+        },
+        mouseleave: this.hideTooltip
       },
       children: [
         ...(this.props.icon != null && this.props.details?.icon == null
@@ -78,6 +89,7 @@ export class ChatItemTreeFile {
             new Icon({ icon: this.props.details?.icon ?? MynahIcons.FILE }).render,
             {
               type: 'span',
+              classNames: [ 'mynah-chat-item-tree-view-file-item-title-text' ],
               children: [ this.props.fileName ]
             } ]
         },

--- a/src/styles/components/chat/_chat-item-tree-view.scss
+++ b/src/styles/components/chat/_chat-item-tree-view.scss
@@ -3,6 +3,7 @@
     margin-block-end: 0 !important;
     margin-block-start: 0 !important;
     padding: var(--mynah-sizing-half);
+    min-width: 100%;
 
     > .mynah-chat-item-tree-view-wrapper-container {
         background-color: var(--mynah-card-bg);
@@ -59,6 +60,9 @@
 
             > .mynah-chat-item-tree-view-button {
                 gap: var(--mynah-sizing-1);
+                & ~ .mynah-chat-item-pull-request-item {
+                    padding-left: var(--mynah-sizing-5);
+                }
             }
 
             .mynah-chat-item-tree-view-button-title {
@@ -77,7 +81,7 @@
             }
 
             .mynah-chat-item-tree-view {
-                padding-left: var(--mynah-sizing-5);
+                // padding-left: var(--mynah-sizing-5);
             }
         }
 
@@ -242,7 +246,7 @@
                 max-width: 100%;
                 overflow: hidden;
                 z-index: 10;
-                flex-shrink: 1;
+                flex-shrink: 0.01;
 
                 > .mynah-ui-icon {
                     opacity: 0.75;

--- a/src/styles/components/chat/_chat-item-tree-view.scss
+++ b/src/styles/components/chat/_chat-item-tree-view.scss
@@ -79,10 +79,6 @@
                 width: 100%;
                 box-sizing: border-box;
             }
-
-            .mynah-chat-item-tree-view {
-                // padding-left: var(--mynah-sizing-5);
-            }
         }
 
         .mynah-chat-item-tree-view-file-item {


### PR DESCRIPTION
fixed auto sizing of the file item until real available space

## Problem
Even though there is enough space in the panel, file names (and also `details`) doesn't push and gets cropped. 

## Solution
- Fixed available space handling through CSS
<img width="415" alt="Screenshot 2024-11-13 at 14 09 06" src="https://github.com/user-attachments/assets/c95ceb8d-8f75-470a-a7bb-d55bb5c91a19">
<img width="927" alt="Screenshot 2024-11-13 at 14 09 01" src="https://github.com/user-attachments/assets/cf69cd1a-b3fd-4548-8450-093469b9ed41">
<img width="1047" alt="Screenshot 2024-11-13 at 14 09 21" src="https://github.com/user-attachments/assets/df860c6a-6e1b-4521-a58c-e06acfcd7817">



- Added tooltip handling for cropped fileNames. If the fileName is cropped due to not available space, it will show up a tooltip. If there is already a `description` which shows the tooltip, they'll be combined.
<img width="205" alt="Screenshot 2024-11-13 at 14 14 33" src="https://github.com/user-attachments/assets/61f4eb7f-b094-455a-94ce-c239fdd87d57">



## Tests
- [X] I have tested this change on VSCode
- [X] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
