### PR TITLE
Increase icon size and make icon color more vivid in Quick Actions pi…

### DIFF
--- a/src/styles/components/chat/_chat-command-selector.scss
+++ b/src/styles/components/chat/_chat-command-selector.scss
@@ -78,9 +78,9 @@
                 }
             }
             > .mynah-ui-icon {
-                margin-top: var(--mynah-sizing-1);
-                font-size: var(--mynah-font-size-small);
-                color: var(--mynah-color-text-weak);
+                margin-top: var(--mynah-sizing-half);
+                font-size: var(--mynah-font-size-large);
+                color: var(--mynah-color-text-default);
             }
 
             > .mynah-chat-command-selector-command-container {


### PR DESCRIPTION
## Problem
The current icon size in the Quick Action commands picker is too small and too dim.

## Solution
Increased the size and enhanced the color of icons in Quick Action commands picker to improve visibility and user experience.

## Tests
- [x] I have tested this change on VSCode

After changes:
<img width="375" alt="Screenshot 2024-11-14 at 15 16 52" src="https://github.com/user-attachments/assets/fe5ca5b5-132a-423f-b224-67b205f238a7">

Before changes:
<img width="364" alt="Screenshot 2024-11-14 at 15 18 50" src="https://github.com/user-attachments/assets/581fd2be-69d7-473a-920f-0e8936e8fd5a">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
