### PR TITLE
Dogusata/hotfix chat container exceeds width

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -5,7 +5,7 @@ on:
     tags: ['beta*.*']
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -52,7 +52,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.18.0",
+    "version": "4.18.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.18.0",
+            "version": "4.18.1",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.18.0",
+    "version": "4.18.1",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/styles/components/chat/_chat-wrapper.scss
+++ b/src/styles/components/chat/_chat-wrapper.scss
@@ -12,7 +12,6 @@
 
     position: relative;
     width: inherit;
-    min-width: inherit;
     max-width: inherit;
     height: 100%;
     flex: 1 0 100%;
@@ -25,7 +24,6 @@
     box-sizing: border-box;
     > div[class^='mynah-chat'] {
         width: inherit;
-        min-width: inherit;
         max-width: inherit;
         box-sizing: border-box;
         padding-left: var(--mynah-sizing-4);


### PR DESCRIPTION
## Problem
When `compactMode` true, middle content exceeds width.
![Screenshot 2024-11-15 at 8 35 26 AM](https://github.com/user-attachments/assets/3c2f43e0-5595-42c2-998d-08dd5ada7b6d)

## Solution
Fixed `min-width` value inheritance.
![image (3)](https://github.com/user-attachments/assets/86d4e660-7905-4675-bfaa-040b373e8148)


## Reason
In our test app and example app, we're not putting mynah UI directly to the body, instead we're using a wrapper. However if it you put into body, it adds a `min-width` value of `100vw` which passes to the element inside with inheritance. That's why our tests are passed but the VSCode (and also JetBrains) had the regression.

Those elements don't require min-width inheritance. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [X] I have tested this change on VSCode
- [X] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
