### PR TITLE
fixed border crop on file list

### DIFF
--- a/src/styles/components/_button.scss
+++ b/src/styles/components/_button.scss
@@ -16,7 +16,7 @@
     outline: none;
     overflow: hidden;
     position: relative;
-    transform: translate3d(0, 0, 0) scale(1.00001);
+    transform: translateZ(0px);
     padding: var(--mynah-sizing-2);
     gap: var(--mynah-sizing-1);
     filter: brightness(0.925);

--- a/src/styles/components/chat/_chat-item-tree-view.scss
+++ b/src/styles/components/chat/_chat-item-tree-view.scss
@@ -4,6 +4,7 @@
     margin-block-start: 0 !important;
     padding: var(--mynah-sizing-half);
     min-width: 100%;
+    box-sizing: border-box;
 
     > .mynah-chat-item-tree-view-wrapper-container {
         background-color: var(--mynah-card-bg);


### PR DESCRIPTION
Fixed border crop on buttons and file list wrappers

## Problem
Sometimes one of the borders of the buttons or the file list wrapper is missing or looks thinner than it should be.
<img width="759" alt="Screenshot 2024-11-18 at 13 54 33" src="https://github.com/user-attachments/assets/01bb340a-78b3-469a-9870-2184cedf64bd">
<img width="718" alt="Screenshot 2024-11-18 at 13 56 20" src="https://github.com/user-attachments/assets/0d6ed6aa-fdcc-4f30-928d-0fcb09b928aa">

## Solution
<img width="728" alt="Screenshot 2024-11-18 at 13 55 17" src="https://github.com/user-attachments/assets/cf51b620-106c-4988-af08-21d54cd4aaf3">
<img width="318" alt="Screenshot 2024-11-18 at 14 06 51" src="https://github.com/user-attachments/assets/2919ec6c-a08d-4520-aa5f-059dafff4504">



## Tests
- [X] I have tested this change on VSCode
- [X] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
