### PR TITLE
[improvement] Fixed GitHub issue template labels, added improvement issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for MynahUI
-labels: feature-request
+labels: new feature
 ---
 
 ## Problem

--- a/.github/ISSUE_TEMPLATE/guidance_request.md
+++ b/.github/ISSUE_TEMPLATE/guidance_request.md
@@ -1,7 +1,7 @@
 ---
 name: Ask a question
 about: Ask for guidance, "how to", or other questions
-labels: guidance
+labels: question
 ---
 
 ## System details

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,0 +1,14 @@
+---
+name: Improvement
+about: Improve a currently existing feature
+labels: improvement
+---
+
+## Current state
+<!-- It currently does ... -->
+
+## Improved behavior
+<!-- But it would be way better if ... -->
+
+## Why?
+<!-- Because, ... -->


### PR DESCRIPTION
## Problem
The labels on the issue templates weren't all correctly matching up with our current labels. Also, we didn't really have a template for a (quality) improvement suggestion.

## Solution
Updated our labels, fixed label mappings, added issue template for improvements.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
