### PR TITLE
[improvement] better syntax highlighting

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -30,14 +30,18 @@
     --mynah-color-toggle-reverse: rgba(0, 0, 0, 0.5);
 
     --mynah-color-syntax-bg: var(--vscode-terminal-dropBackground);
-    --mynah-color-syntax-variable: var(--vscode-debugTokenExpression-name);
+    --mynah-color-syntax-variable: var(--vscode-terminal-ansiYellow);
     --mynah-color-syntax-function: var(--vscode-gitDecoration-modifiedResourceForeground);
-    --mynah-color-syntax-operator: var(--vscode-debugTokenExpression-name);
-    --mynah-color-syntax-attr-value: var(--vscode-debugIcon-stepBackForeground);
-    --mynah-color-syntax-attr: var(--vscode-debugTokenExpression-string);
+    --mynah-color-syntax-operator: var(--vscode-terminal-foreground);
     --mynah-color-syntax-property: var(--vscode-terminal-ansiCyan);
     --mynah-color-syntax-comment: var(--vscode-debugConsole-sourceForeground);
     --mynah-color-syntax-code: var(--vscode-editor-foreground, var(--mynah-color-text-default, inherit));
+    --mynah-color-syntax-keyword: var(--vscode-debugTokenExpression-name);
+    --mynah-color-syntax-string: var(--vscode-debugTokenExpression-string);
+    --mynah-color-syntax-boolean: var(--vscode-debugTokenExpression-boolean);
+    --mynah-color-syntax-number: var(--vscode-debugTokenExpression-number);
+    --mynah-color-syntax-regex: var(--vscode-terminal-ansiMagenta);
+    --mynah-color-syntax-class-name: var(--vscode-terminal-ansiYellow);
 
     --mynah-color-status-info: #0971d3;
     --mynah-color-status-success: #037f03;

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -182,77 +182,87 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             background: #b3d4fc;
         }
 
-        .token.comment,
-        .token.prolog,
-        .token.doctype,
-        .token.cdata {
-            color: var(--mynah-color-syntax-comment);
+        .token {
+            &.comment,
+            &.prolog,
+            &.doctype,
+            &.cdata {
+                color: var(--mynah-color-syntax-comment); 
+                font-style: italic;
+            }
+        
+            &.keyword {
+                color: var(--mynah-color-syntax-keyword);
+                font-style: italic;
+            }
+        
+            &.string,
+            &.char,
+            &.attr-value,
+            &.builtin,
+            &.deleted,
+            &.inserted,
+            &.tag,
+            &.symbol {
+                color: var(--mynah-color-syntax-string);
+            }
+        
+            &.number,
+            &.integer,
+            &.float {
+                color: var(--mynah-color-syntax-number);
+            }
+
+            &.namespace {
+                opacity: 0.7;
+            }
+        
+            &.boolean {
+                color: var(--mynah-color-syntax-boolean);
+            }
+        
+            &.function {
+                color: var(--mynah-color-syntax-function);
+            }
+        
+            &.class-name {
+                color: var(--mynah-color-syntax-class-name);
+            }
+        
+            &.operator,
+            &.punctuation,
+            &.url {
+                color: var(--mynah-color-syntax-operator);
+            }
+        
+            &.important,
+            &.variable,
+            &.parameter {
+                color: var(--mynah-color-syntax-variable);
+            }
+        
+            &.constant,
+            &.property {
+                color: var(--mynah-color-syntax-property);
+            }
+        
+            &.regex {
+                color: var(--mynah-color-syntax-regex);
+            }
+            
+            &.important,
+            &.bold {
+                font-weight: bold;
+            }
+        
+            &.italic {
+                font-style: italic;
+            }
         }
 
-        .token.punctuation {
-            color: currentColor;
-        }
-
-        .token.namespace {
-            opacity: 0.7;
-        }
-
-        .token.property,
-        .token.tag,
-        .token.boolean,
-        .token.number,
-        .token.constant,
-        .token.symbol,
-        .token.inserted {
-            color: var(--mynah-color-syntax-property);
-        }
-
-        .token.selector,
-        .token.attr-name,
-        .token.string,
-        .token.char,
-        .token.builtin,
-        .token.deleted {
-            color: var(--mynah-color-syntax-attr);
-        }
-
-        .token.operator,
-        .token.entity,
-        .token.url,
         .language-css .token.string,
         .style .token.string {
             color: var(--mynah-color-syntax-operator);
-        }
-
-        .token.atrule,
-        .token.attr-value,
-        .token.class-name,
-        .token.keyword {
-            color: var(--mynah-color-syntax-attr-value);
-        }
-
-        .token.function {
-            color: var(--mynah-color-syntax-function);
-            font-weight: 500;
-        }
-
-        .token.regex,
-        .token.important,
-        .token.variable {
-            color: var(--mynah-color-syntax-variable);
-            font-weight: 500;
-        }
-
-        .token.important,
-        .token.bold {
-            font-weight: bold;
-        }
-        .token.italic {
-            font-style: italic;
-        }
-
-        .token.entity {
-            cursor: help;
         }
 
         &.line-numbers {

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -187,15 +187,15 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             &.prolog,
             &.doctype,
             &.cdata {
-                color: var(--mynah-color-syntax-comment); 
+                color: var(--mynah-color-syntax-comment);
                 font-style: italic;
             }
-        
+
             &.keyword {
                 color: var(--mynah-color-syntax-keyword);
                 font-style: italic;
             }
-        
+
             &.string,
             &.char,
             &.attr-value,
@@ -206,7 +206,7 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             &.symbol {
                 color: var(--mynah-color-syntax-string);
             }
-        
+
             &.number,
             &.integer,
             &.float {
@@ -216,45 +216,45 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             &.namespace {
                 opacity: 0.7;
             }
-        
+
             &.boolean {
                 color: var(--mynah-color-syntax-boolean);
             }
-        
+
             &.function {
                 color: var(--mynah-color-syntax-function);
             }
-        
+
             &.class-name {
                 color: var(--mynah-color-syntax-class-name);
             }
-        
+
             &.operator,
             &.punctuation,
             &.url {
                 color: var(--mynah-color-syntax-operator);
             }
-        
+
             &.important,
             &.variable,
             &.parameter {
                 color: var(--mynah-color-syntax-variable);
             }
-        
+
             &.constant,
             &.property {
                 color: var(--mynah-color-syntax-property);
             }
-        
+
             &.regex {
                 color: var(--mynah-color-syntax-regex);
             }
-            
+
             &.important,
             &.bold {
                 font-weight: bold;
             }
-        
+
             &.italic {
                 font-style: italic;
             }


### PR DESCRIPTION
## Problem
Currently, the syntax highlighting can sometimes be suboptimal and unclear, compared to an IDE as VSCode.

## Solution
Improved color mappings, mapped some more different token tags. 
### Before:
<img width="575" alt="Screenshot 2024-11-21 at 12 14 57" src="https://github.com/user-attachments/assets/a19db985-62b9-4aaf-b328-b204ba71ca40">

### After (In VSCode):
<img width="543" alt="Screenshot 2024-11-21 at 12 14 28" src="https://github.com/user-attachments/assets/dd4a56cf-a257-42ae-bb97-d703f7e39f68">

### After (In IntelliJ):
<img width="701" alt="Screenshot 2024-11-21 at 14 05 22" src="https://github.com/user-attachments/assets/fed61e6e-8147-4556-92ac-92d2efcab6ea">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [x] I have tested this change on VSCode
- [x] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
