### PR TITLE
Add up down arrow navigation in prompt field to access prompts in history

### DIFF
--- a/example/src/globals.d.ts
+++ b/example/src/globals.d.ts
@@ -4,3 +4,7 @@ declare module "escape-html" {
     function escapeHTML(a:string): string;
     export = escapeHTML;
 }
+declare module "unescape-html" {
+    function unescapeHTML(a:string): string;
+    export = unescapeHTML;
+}

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -387,6 +387,7 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
     onInfoLinkClick: (tabId, link, mouseEvent) => {
       Log(`Link inside prompt info field clicked: <b>${link}</b>`);
     },
+    upDownArrowKeyPress(tabId: string, direction: 'up' | 'down') {  
   });
 
   const onChatPrompt = (tabId: string, prompt: ChatPrompt) => {

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -232,7 +232,7 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
       }
       // reset navigation index when sending a new prompt
       mynahUI.updateStore(tabId, {
-        navigationIndexChatPrompts: -1,
+        upDownKeyNavigationIndex: -1,
       })
 
       onChatPrompt(tabId, prompt);
@@ -393,36 +393,33 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
     onInfoLinkClick: (tabId, link, mouseEvent) => {
       Log(`Link inside prompt info field clicked: <b>${link}</b>`);
     },
-    upDownArrowKeyPress(tabId: string, direction: 'up' | 'down') {  
+    onUpDownArrowKeyPress(tabId: string, direction: 'up' | 'down') {  
       // reset promptInputText and any possible attachment/commands from previous prompts
       mynahUI.updateStore(tabId, {
         promptInputText: '',
       });
       mynahUI.clearPrompt(tabId);
 
-      const tab = mynahUI.getAllTabs()[tabId];
+      const currentTab = mynahUI.getAllTabs()[tabId];
 
-      if (!tab?.store?.chatItems) { return; }
+      if (!currentTab?.store?.chatItems) { return; }
 
-      const chatPrompts = tab.store.chatItems.filter(item => item.type === ChatItemType.PROMPT);   
+      const chatPrompts = currentTab.store.chatItems.filter(item => item.type === ChatItemType.PROMPT);   
   
       if (!chatPrompts.length) { return; }
 
-      let navigationIndex = tab.store.navigationIndexChatPrompts === -1 ? chatPrompts.length : (tab.store.navigationIndexChatPrompts ?? chatPrompts.length);  
+      let navigationIndex = currentTab.store.upDownKeyNavigationIndex === -1 ? chatPrompts.length : (currentTab.store.upDownKeyNavigationIndex ?? chatPrompts.length);  
     
       if (direction === 'up') {
           navigationIndex = Math.max(0, navigationIndex - 1);
       } else if (direction === 'down') {
           navigationIndex = Math.min(chatPrompts.length, navigationIndex + 1);
-      } else {
-          Log(`direction ${direction} does not exist`);
-          return;
       }
   
       // If we've reached the end (newest message), reset to empty state
       if (navigationIndex === chatPrompts.length) {
           mynahUI.updateStore(tabId, {
-            navigationIndexChatPrompts: -1
+            upDownKeyNavigationIndex: -1
           });
           return;
       } else {
@@ -437,7 +434,7 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
           // Update promptInputText with the combined text
           mynahUI.updateStore(tabId, {
               promptInputText: promptInputText,
-              navigationIndexChatPrompts: navigationIndex
+              upDownKeyNavigationIndex: navigationIndex
           });
           
           // check if any codeSnippet was present at the currently indexed prompt

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -319,7 +319,7 @@ export class ChatPromptInput {
             MynahEventNames.UP_DOWN_ARROW_KEY_PRESS, 
             { tabId: this.props.tabId, direction: direction }
         );
-      }
+     }
     } else {
       const blockedKeys = [ KeyMap.ENTER, KeyMap.ESCAPE, KeyMap.SPACE, KeyMap.TAB, KeyMap.AT, KeyMap.BACK_SLASH, KeyMap.SLASH ] as string[];
       if (blockedKeys.includes(e.key)) {
@@ -616,12 +616,17 @@ export class ChatPromptInput {
         return `**${match}**`;
       }));
 
+      const escapedInputText = escapeHTML(currentInputValue);
+      const escapedAttachmentContent = escapeHTML(attachmentContent);
+
       const promptData: {tabId: string; prompt: ChatPrompt} = {
         tabId: this.props.tabId,
         prompt: {
           prompt: promptText,
-          escapedPrompt,
-          context,
+          escapedPrompt: escapedPrompt,
+          context: context,
+          attachmentContent: escapedAttachmentContent,
+          inputText: escapedInputText,     
           ...(selectedCommand !== '' ? { command: selectedCommand } : {}),
         }
       };
@@ -662,4 +667,9 @@ export class ChatPromptInput {
       type
     });
   };
+
+  public readonly addCommand = (quickActionCommand: string): void => {
+    this.selectedCommand = quickActionCommand;
+    this.promptTextInputCommand.setCommand(this.selectedCommand);
+  }  
 }

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -668,7 +668,7 @@ export class ChatPromptInput {
     });
   };
 
-  public readonly addCommand = (quickActionCommand: string): void => {
+  public readonly setCommand = (quickActionCommand: string): void => {
     this.selectedCommand = quickActionCommand;
     this.promptTextInputCommand.setCommand(this.selectedCommand);
   };

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -250,6 +250,7 @@ export class ChatPromptInput {
   };
 
   private readonly handleInputKeydown = (e: KeyboardEvent): void => {
+    const navigationalKeys = [ KeyMap.ARROW_UP, KeyMap.ARROW_DOWN ] as string[];
     if (e.key === KeyMap.ESCAPE && this.render.hasClass('awaits-confirmation')) {
       this.promptTextInput.blur();
     }
@@ -312,10 +313,15 @@ export class ChatPromptInput {
 
           this.quickPickOpen = true;
         }
+      } else if (navigationalKeys.includes(e.key)) {
+        const direction = e.key === KeyMap.ARROW_UP ? 'up' : 'down';
+        MynahUIGlobalEvents.getInstance().dispatch(
+            MynahEventNames.UP_DOWN_ARROW_KEY_PRESS, 
+            { tabId: this.props.tabId, direction: direction }
+        );
       }
     } else {
       const blockedKeys = [ KeyMap.ENTER, KeyMap.ESCAPE, KeyMap.SPACE, KeyMap.TAB, KeyMap.AT, KeyMap.BACK_SLASH, KeyMap.SLASH ] as string[];
-      const navigationalKeys = [ KeyMap.ARROW_UP, KeyMap.ARROW_DOWN ] as string[];
       if (blockedKeys.includes(e.key)) {
         e.preventDefault();
         if (e.key === KeyMap.ESCAPE) {

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -316,10 +316,10 @@ export class ChatPromptInput {
       } else if (navigationalKeys.includes(e.key)) {
         const direction = e.key === KeyMap.ARROW_UP ? 'up' : 'down';
         MynahUIGlobalEvents.getInstance().dispatch(
-            MynahEventNames.UP_DOWN_ARROW_KEY_PRESS, 
-            { tabId: this.props.tabId, direction: direction }
+          MynahEventNames.UP_DOWN_ARROW_KEY_PRESS,
+          { tabId: this.props.tabId, direction }
         );
-     }
+      }
     } else {
       const blockedKeys = [ KeyMap.ENTER, KeyMap.ESCAPE, KeyMap.SPACE, KeyMap.TAB, KeyMap.AT, KeyMap.BACK_SLASH, KeyMap.SLASH ] as string[];
       if (blockedKeys.includes(e.key)) {
@@ -623,10 +623,10 @@ export class ChatPromptInput {
         tabId: this.props.tabId,
         prompt: {
           prompt: promptText,
-          escapedPrompt: escapedPrompt,
-          context: context,
+          escapedPrompt,
+          context,
           attachmentContent: escapedAttachmentContent,
-          inputText: escapedInputText,     
+          inputText: escapedInputText,
           ...(selectedCommand !== '' ? { command: selectedCommand } : {}),
         }
       };
@@ -671,5 +671,5 @@ export class ChatPromptInput {
   public readonly addCommand = (quickActionCommand: string): void => {
     this.selectedCommand = quickActionCommand;
     this.promptTextInputCommand.setCommand(this.selectedCommand);
-  }  
+  };
 }

--- a/src/components/chat-item/chat-wrapper.ts
+++ b/src/components/chat-item/chat-wrapper.ts
@@ -351,4 +351,12 @@ export class ChatWrapper {
   public addAttachmentToPrompt = (textToAdd: string, type?: PromptAttachmentType): void => {
     this.promptInput.addAttachment(textToAdd, type);
   };
+
+  public addCommandToPrompt = (quickActionCommand: string): void => {
+    this.promptInput.addCommand(quickActionCommand);
+  };
+
+  public clearTextArea = (): void => {
+    this.promptInput.clearTextArea();
+  }
 }

--- a/src/components/chat-item/chat-wrapper.ts
+++ b/src/components/chat-item/chat-wrapper.ts
@@ -353,7 +353,7 @@ export class ChatWrapper {
   };
 
   public addCommandToPrompt = (quickActionCommand: string): void => {
-    this.promptInput.addCommand(quickActionCommand);
+    this.promptInput.setCommand(quickActionCommand);
   };
 
   public clearTextArea = (): void => {

--- a/src/components/chat-item/chat-wrapper.ts
+++ b/src/components/chat-item/chat-wrapper.ts
@@ -358,5 +358,5 @@ export class ChatWrapper {
 
   public clearTextArea = (): void => {
     this.promptInput.clearTextArea();
-  }
+  };
 }

--- a/src/helper/store.ts
+++ b/src/helper/store.ts
@@ -37,6 +37,7 @@ export class EmptyMynahUIDataModel {
       tabBarButtons: [],
       compactMode: false,
       tabHeaderDetails: null,
+      navigationIndexChatPrompts: -1,
       ...defaults
     };
   }

--- a/src/helper/store.ts
+++ b/src/helper/store.ts
@@ -37,7 +37,7 @@ export class EmptyMynahUIDataModel {
       tabBarButtons: [],
       compactMode: false,
       tabHeaderDetails: null,
-      navigationIndexChatPrompts: -1,
+      upDownKeyNavigationIndex: -1,
       ...defaults
     };
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -634,7 +634,6 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
         this.props.upDownArrowKeyPress(data.tabId, data.direction, this.getUserEventId());
       }
     });
-
   };
 
   public addToUserPrompt = (tabId: string, attachmentContent: string, type?: PromptAttachmentType): void => {
@@ -645,17 +644,16 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
 
   public addCommandToUserPrompt = (tabId: string, command: string): void => {
     if (Config.getInstance().config.showPromptField && MynahUITabsStore.getInstance().getTab(tabId) !== null) {
-      this.chatWrappers[tabId].addCommandToPrompt(command)
+      this.chatWrappers[tabId].addCommandToPrompt(command);
     }
   };
 
   public clearPrompt = (tabId: string): void => {
     if (Config.getInstance().config.showPromptField && MynahUITabsStore.getInstance().getTab(tabId) !== null) {
-      this.chatWrappers[tabId].clearTextArea()
+      this.chatWrappers[tabId].clearTextArea();
     }
   };
 
-  
   /**
    * Adds a new item to the chat window
    * @param tabId Corresponding tab ID.

--- a/src/main.ts
+++ b/src/main.ts
@@ -246,6 +246,10 @@ export interface MynahUIProps {
     tabId: string,
     buttonId: string,
     eventId?: string) => void;
+  upDownArrowKeyPress?: (
+    tabId: string,
+    direction: 'up' | 'down',
+    eventId?: string) => void;
 }
 
 export class MynahUI {
@@ -624,6 +628,13 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
         this.props.onTabBarButtonClick(data.tabId, data.buttonId, this.getUserEventId());
       }
     });
+
+    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.UP_DOWN_ARROW_KEY_PRESS, (data) => {
+      if (this.props.upDownArrowKeyPress !== undefined) {
+        this.props.upDownArrowKeyPress(data.tabId, data.direction, this.getUserEventId());
+      }
+    });
+
   };
 
   public addToUserPrompt = (tabId: string, attachmentContent: string, type?: PromptAttachmentType): void => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -246,7 +246,7 @@ export interface MynahUIProps {
     tabId: string,
     buttonId: string,
     eventId?: string) => void;
-  upDownArrowKeyPress?: (
+  onUpDownArrowKeyPress?: (
     tabId: string,
     direction: 'up' | 'down',
     eventId?: string) => void;
@@ -630,8 +630,8 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
     });
 
     MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.UP_DOWN_ARROW_KEY_PRESS, (data) => {
-      if (this.props.upDownArrowKeyPress !== undefined) {
-        this.props.upDownArrowKeyPress(data.tabId, data.direction, this.getUserEventId());
+      if (this.props.onUpDownArrowKeyPress !== undefined) {
+        this.props.onUpDownArrowKeyPress(data.tabId, data.direction, this.getUserEventId());
       }
     });
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -643,6 +643,19 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
     }
   };
 
+  public addCommandToUserPrompt = (tabId: string, command: string): void => {
+    if (Config.getInstance().config.showPromptField && MynahUITabsStore.getInstance().getTab(tabId) !== null) {
+      this.chatWrappers[tabId].addCommandToPrompt(command)
+    }
+  };
+
+  public clearPrompt = (tabId: string): void => {
+    if (Config.getInstance().config.showPromptField && MynahUITabsStore.getInstance().getTab(tabId) !== null) {
+      this.chatWrappers[tabId].clearTextArea()
+    }
+  };
+
+  
   /**
    * Adds a new item to the chat window
    * @param tabId Corresponding tab ID.

--- a/src/static.ts
+++ b/src/static.ts
@@ -126,6 +126,10 @@ export interface MynahUIDataModel {
    * Tab content header details, only visibile when showTabHeaderDetails is set to 'true'
    */
   tabHeaderDetails?: TabHeaderDetails | null;
+  /**
+   * The navigation index for the chat prompts list for the up/down arrow key navigation
+   */
+  navigationIndexChatPrompts?: number;
 }
 
 export interface MynahUITabStoreTab {
@@ -246,6 +250,9 @@ export interface TreeNodeDetails {
 
 export interface ChatItemContent {
   body?: string | null;
+  inputText?: string | null;
+  codeSnippet?: string | null;
+  quickActionCommand?: string | null;
   customRenderer?: string | ChatItemBodyRenderer | ChatItemBodyRenderer[] | null;
   followUp?: {
     text?: string;
@@ -312,6 +319,8 @@ export interface ChatPrompt {
   escapedPrompt?: string;
   command?: string;
   context?: string[];
+  attachmentContent?: string;
+  inputText?: string;
 }
 
 export interface ChatItemAction extends ChatPrompt {

--- a/src/static.ts
+++ b/src/static.ts
@@ -171,6 +171,7 @@ export enum MynahEventNames {
   REMOVE_ATTACHMENT = 'removeAttachment',
   TAB_BAR_BUTTON_CLICK = 'tabBarButtonClick',
   PROMPT_PROGRESS_ACTION_CLICK = 'promptProgressActionClick',
+  UP_DOWN_ARROW_KEY_PRESS = 'upDownArrowKeyPress',
 };
 
 export enum MynahPortalNames {

--- a/src/static.ts
+++ b/src/static.ts
@@ -129,7 +129,7 @@ export interface MynahUIDataModel {
   /**
    * The navigation index for the chat prompts list for the up/down arrow key navigation
    */
-  navigationIndexChatPrompts?: number;
+  upDownKeyNavigationIndex?: number;
 }
 
 export interface MynahUITabStoreTab {

--- a/src/static.ts
+++ b/src/static.ts
@@ -99,7 +99,7 @@ export interface MynahUIDataModel {
   */
   promptInputStickyCard?: Partial<ChatItem> | null;
   /**
-  * Prompt input field disabled state, set to tru to disable it
+  * Prompt input field disabled state, set to true to disable it
   */
   promptInputDisabledState?: boolean;
   /**


### PR DESCRIPTION
## Problem
Up and down keys inside the prompt input field should switch between previous prompts like in a terminal. To increase the UX and let the end user easily access to a previous prompt to modify/improve it, the approach used in terminals needs to be applied.

Once I receive validation for my implementation approach I will proceed with adding tests and documentation.

## Solution
Retrieving and identifying commands and code snippets from previous chat prompts, required adding some extra properties and methods that were not current available. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
