### PR TITLE
[improvement] consider hiding cursor in prompt input during command confirmation

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -346,7 +346,17 @@ export class ChatPromptInput {
               this.handleContextCommandSelection({ command });
             }
           } else {
-            this.handleQuickActionCommandSelection(commandToSend);
+            switch (e.key) {
+              case KeyMap.SPACE:
+                this.handleQuickActionCommandSelection(commandToSend, 'space');
+                break;
+              case KeyMap.TAB:
+                this.handleQuickActionCommandSelection(commandToSend, 'tab');
+                break;
+              case KeyMap.ENTER:
+                this.handleQuickActionCommandSelection(commandToSend, 'enter');
+                break;
+            }
           }
         }
       } else if (navigationalKeys.includes(e.key)) {
@@ -508,7 +518,7 @@ export class ChatPromptInput {
                       if (this.quickPickType === 'context') {
                         this.handleContextCommandSelection(quickPickCommand);
                       } else {
-                        this.handleQuickActionCommandSelection(quickPickCommand);
+                        this.handleQuickActionCommandSelection(quickPickCommand, 'click');
                       }
                     }
                   }
@@ -548,12 +558,14 @@ export class ChatPromptInput {
     });
   };
 
-  private readonly handleQuickActionCommandSelection = (quickActionCommand: QuickActionCommand): void => {
+  private readonly handleQuickActionCommandSelection = (quickActionCommand: QuickActionCommand, method: 'enter' | 'tab' | 'space' | 'click'): void => {
     this.selectedCommand = quickActionCommand.command;
     this.promptTextInput.updateTextInputValue('');
     if (quickActionCommand.placeholder !== undefined) {
       this.promptTextInputCommand.setCommand(this.selectedCommand);
       this.promptTextInput.updateTextInputPlaceholder(quickActionCommand.placeholder);
+    } else if (method === 'enter' || method === 'click') {
+      this.sendPrompt();
     } else {
       this.promptTextInputCommand.setCommand(this.selectedCommand);
       this.promptTextInput.updateTextInputPlaceholder(Config.getInstance().config.texts.commandConfirmation);

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -9,6 +9,10 @@
         }
     }
 
+    &.awaits-confirmation .mynah-chat-prompt-input {
+        caret-color: transparent !important;
+    }
+
     > .mynah-chat-prompt-input-label {
         transition: var(--mynah-short-transition);
         padding: var(--mynah-sizing-2) 0;


### PR DESCRIPTION
## Problem
Currently, when a command is waiting to be confirmed to be sent, the cursor still blinks in the prompt input textarea, even though the user can't type anything. Someone reported this as unexpected behavior, so an alternative should be considered.

## Solution
Cursor is hidden when in command confirmation state. Also, now the command confirmation only shows up when a command is selected in the list through either `tab` or `space` (so `enter` / clicking will instantly send the command again, except for when there are arguments / parameters of course). 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
