### PR TITLE
Extended new PR GitHub workflow to send notification to Slack channel

### DIFF
--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -3,6 +3,21 @@ on:
   pull_request:
     branches: [main, feature/*, fix/*]
 jobs:
+  notify:
+    name: Slack notification
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Post message
+        uses: slackapi/slack-github-action@v1.25.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          payload: |
+            {
+              "title": ${{ toJson(github.event.pull_request.title) }},
+              "author": ${{ toJson(github.event.pull_request.user.login) }},
+              "link": ${{ toJson(github.event.pull_request.html_url) }}
+            }
   build:
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
## Description
Extended new PR GitHub workflow to send notification to Slack channel.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
