### PR TITLE
Add syntax fallback colors

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -30,17 +30,17 @@
     --mynah-color-toggle-reverse: rgba(0, 0, 0, 0.5);
 
     --mynah-color-syntax-bg: var(--vscode-terminal-dropBackground);
-    --mynah-color-syntax-variable: var(--vscode-gitDecoration-modifiedResourceForeground);
-    --mynah-color-syntax-function: var(--vscode-debugTokenExpression-boolean);
-    --mynah-color-syntax-operator: var(--vscode-terminal-foreground);
+    --mynah-color-syntax-variable: var(--vscode-gitDecoration-modifiedResourceForeground, var(--vscode-debugTokenExpression-name));
+    --mynah-color-syntax-function: var(--vscode-debugTokenExpression-boolean, var(--vscode-gitDecoration-modifiedResourceForeground));
+    --mynah-color-syntax-operator: var(--vscode-terminal-foreground, var(--vscode-debugTokenExpression-name));
     --mynah-color-syntax-property: var(--vscode-terminal-ansiCyan);
     --mynah-color-syntax-comment: var(--vscode-debugConsole-sourceForeground);
     --mynah-color-syntax-code: var(--vscode-editor-foreground, var(--mynah-color-text-default));
     --mynah-color-syntax-keyword: var(--vscode-debugTokenExpression-name);
     --mynah-color-syntax-string: var(--vscode-debugTokenExpression-string);
-    --mynah-color-syntax-boolean: var(--vscode-debugTokenExpression-boolean);
-    --mynah-color-syntax-number: var(--vscode-debugTokenExpression-number);
-    --mynah-color-syntax-regex: var(--vscode-terminal-ansiMagenta);
+    --mynah-color-syntax-boolean: var(--vscode-debugTokenExpression-boolean, var(--vscode-debugTokenExpression-string));
+    --mynah-color-syntax-number: var(--vscode-debugTokenExpression-number, var(--vscode-debugTokenExpression-string));
+    --mynah-color-syntax-regex: var(--vscode-terminal-ansiMagenta, var(--vscode-debugTokenExpression-string));
     --mynah-color-syntax-class-name: var(--vscode-gitDecoration-modifiedResourceForeground);
 
     --mynah-color-status-info: #0971d3;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -30,8 +30,14 @@
     --mynah-color-toggle-reverse: rgba(0, 0, 0, 0.5);
 
     --mynah-color-syntax-bg: var(--vscode-terminal-dropBackground);
-    --mynah-color-syntax-variable: var(--vscode-gitDecoration-modifiedResourceForeground, var(--vscode-debugTokenExpression-name));
-    --mynah-color-syntax-function: var(--vscode-debugTokenExpression-boolean, var(--vscode-gitDecoration-modifiedResourceForeground));
+    --mynah-color-syntax-variable: var(
+        --vscode-gitDecoration-modifiedResourceForeground,
+        var(--vscode-debugTokenExpression-name)
+    );
+    --mynah-color-syntax-function: var(
+        --vscode-debugTokenExpression-boolean,
+        var(--vscode-gitDecoration-modifiedResourceForeground)
+    );
     --mynah-color-syntax-operator: var(--vscode-terminal-foreground, var(--vscode-debugTokenExpression-name));
     --mynah-color-syntax-property: var(--vscode-terminal-ansiCyan);
     --mynah-color-syntax-comment: var(--vscode-debugConsole-sourceForeground);


### PR DESCRIPTION
## Problem
The updated syntax highlighting colors were causing some weird highlighting in several themes.

## Solution
Add in some fallback color variables, with the initial values before the PR that updated them was merged.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests -> NA
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
