### PR TITLE
Added repository name to Slack PR webhook payload

### DIFF
--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -16,7 +16,8 @@ jobs:
             {
               "title": ${{ toJson(github.event.pull_request.title) }},
               "author": ${{ toJson(github.event.pull_request.user.login) }},
-              "link": ${{ toJson(github.event.pull_request.html_url) }}
+              "link": ${{ toJson(github.event.pull_request.html_url) }},
+              "repository": "FlareChatUI" 
             }
   build:
     runs-on: macos-latest


### PR DESCRIPTION
## Solution
Added "repository" key to the webhook payload, so that it can be reused for the `language-servers` and `language-server-runtimes` repositories as well.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
