### PR TITLE
Renamed @aws/dexp to @aws/flare in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aws/dexp
+* @aws/flare


### PR DESCRIPTION
## Problem
As part of the renaming of "DEXP" to "Flare", the team name on GitHub has changed, and so the `.github/CODEOWNERS` file in this repository should be updated accordingly.

## Solution
Updated the `.github/CODEOWNERS` file accordingly.

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
