### PR TITLE
Adjust footer text size

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,2 @@
 npm run lint
 npm run format:check
-npm run tests:e2e

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.21.0",
+    "version": "4.21.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.21.0",
+            "version": "4.21.1",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.21.0",
+    "version": "4.21.1",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -127,7 +127,7 @@
     --mynah-font-size-large: 1.25rem;
     --mynah-font-size-xlarge: 1.4rem;
     --mynah-font-size-xxlarge: 1.6rem;
-    --mynah-line-height: 1.5rem;
+    --mynah-line-height: 1.25rem;
 
     --mynah-syntax-code-line-height: 1.5rem;
     --mynah-syntax-code-font-size: var(--vscode-editor-font-size, var(--mynah-font-size-medium));

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -355,7 +355,6 @@
     &,
     & * {
         font-size: var(--mynah-font-size-xsmall) !important;
-        line-height: var(--mynah-font-size-xsmall) !important;
     }
 
     &:empty {

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -354,7 +354,8 @@
 
     &,
     & * {
-        font-size: var(--mynah-font-size-xsmall);
+        font-size: var(--mynah-font-size-xxsmall) !important;
+        line-height: var(--mynah-font-size-xxsmall) !important;
     }
 
     &:empty {

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -354,8 +354,8 @@
 
     &,
     & * {
-        font-size: var(--mynah-font-size-xxsmall) !important;
-        line-height: var(--mynah-font-size-xxsmall) !important;
+        font-size: var(--mynah-font-size-xsmall) !important;
+        line-height: var(--mynah-font-size-xsmall) !important;
     }
 
     &:empty {


### PR DESCRIPTION
## Problem
The footer text size and the line-height (in general) is too much and when there is a long disclaimer text it takes too much screen real estate.
![image](https://github.com/user-attachments/assets/e6523c81-8a50-43f7-a90c-dff174001158)


## Solution
The given font size to the footer was being overridden, made it !important to avoid overrides. Also, reduced the line-height in general as requested.


### Additionally
We have much more tests now and they are taking too much time and resources on local. Removing the `tests:e2e` step from the prepush to leave the test runs to github actions.

## Tests
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
