### PR TITLE
Avoid resetting last unsent user prompt when navigating with up and down arrows

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -346,14 +346,14 @@ export class ChatPromptInput {
         let codeAttachment = '';
         if (this.userPromptHistoryIndex === this.userPromptHistory.length) {
           MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).updateStore({
-            promptInputText: this.lastUnsentUserPrompt.inputText,
+            promptInputText: this.lastUnsentUserPrompt.inputText ?? '',
           });
-          codeAttachment = this.lastUnsentUserPrompt.codeAttachment;
+          codeAttachment = this.lastUnsentUserPrompt.codeAttachment ?? '';
         } else {
           MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).updateStore({
             promptInputText: this.userPromptHistory[this.userPromptHistoryIndex].inputText,
           });
-          codeAttachment = this.userPromptHistory[this.userPromptHistoryIndex].codeAttachment;
+          codeAttachment = this.userPromptHistory[this.userPromptHistoryIndex].codeAttachment ?? '';
         }
         if (codeAttachment.trim().length > 0) {
           codeAttachment = codeAttachment


### PR DESCRIPTION
## Problem
We should keep track of the last unsent user prompt when navigating with the up and down arrow through previous prompts. When the user navigates through previous prompts, they should be able to go back to the prompt they are currently writing which should not be reset. This behaviour is of particular relevance when writing a prompt and accidentally press the up or down arrow key, which would reset the prompt.

## Solution
Keep track of the current prompt being written (last unsent user prompt)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
