### PR TITLE
Fix code marks trimming for different ides

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -355,11 +355,20 @@ export class ChatPromptInput {
           });
           codeAttachment = this.userPromptHistory[this.userPromptHistoryIndex].codeAttachment ?? '';
         }
-        if (codeAttachment.trim().length > 0) {
-          codeAttachment = codeAttachment
-            .replace(/~~~~~~~~~~/, '')
-            .replace(/~~~~~~~~~~$/, '')
-            .trim();
+        codeAttachment = codeAttachment.trim();
+        if (codeAttachment.length > 0) {
+          // our example
+          if (codeAttachment.startsWith('~~~~~~~~~~') && codeAttachment.endsWith('~~~~~~~~~~')) {
+            codeAttachment = codeAttachment
+              .replace(/^~~~~~~~~~~/, '')
+              .replace(/~~~~~~~~~~$/, '')
+              .trim();
+          } else if (codeAttachment.startsWith('```') && codeAttachment.endsWith('```')) {
+            codeAttachment = codeAttachment
+              .replace(/^```/, '')
+              .replace(/```$/, '')
+              .trim();
+          }
           this.addAttachment(codeAttachment, 'code');
         }
       }

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -357,13 +357,14 @@ export class ChatPromptInput {
         }
         codeAttachment = codeAttachment.trim();
         if (codeAttachment.length > 0) {
-          // our example
+          // the way we mark code in our example mynah client
           if (codeAttachment.startsWith('~~~~~~~~~~') && codeAttachment.endsWith('~~~~~~~~~~')) {
             codeAttachment = codeAttachment
               .replace(/^~~~~~~~~~~/, '')
               .replace(/~~~~~~~~~~$/, '')
               .trim();
           } else if (codeAttachment.startsWith('```') && codeAttachment.endsWith('```')) {
+            // the way code is marked in VScode and JetBrains extensions
             codeAttachment = codeAttachment
               .replace(/^```/, '')
               .replace(/```$/, '')

--- a/ui-tests/__test__/main.spec.ts
+++ b/ui-tests/__test__/main.spec.ts
@@ -216,7 +216,7 @@ describe('Open MynahUI', () => {
     it('should navigate down to next prompt', async () => {
       await navigatePromptsDown(page);
     },
-    20000);
+    25000);
     it('should navigate down to current empty prompt', async () => {
       await navigatePromptsToEmpty(page);
     });


### PR DESCRIPTION
## Problem
in our example mynah-ui we mark codeblock with \~~~~~~~~~~, different ides use \``` instead. This causes a small ui issue when navigating through prompts as the code blocks attached to previous prompts might not be trimmed correctly. More importantly, in this PR we make sure to remove the code marks ONLY if they appear at the very start of the codeAttachment, not the first occurrence. This issue could have potentially modified the user prompt if it contained an occurrence of  \~~~~~~~~~~ while the code block was marked via the \``` marks. In that case navigating through prompts would have caused an input like:
```
void main() {
  print("~~~~~~~~~~");
  print("Hello World");
  print("Hello World");
}
```

to be transformed to 
```
void main() {
  print("");
  print("Hello World");
  print("Hello World");
}
```

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
