### PR TITLE
updated version to v4.21.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.21.1",
+    "version": "4.21.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.21.1",
+            "version": "4.21.2",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.21.1",
+    "version": "4.21.2",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",


### PR DESCRIPTION
Version update to **v4.21.2**

This update fixes two minor issues related to the recently introduced up/down arrows prompt navigation (like in the terminal):

1. When user is currently writing a prompt without sending it, and navigate through previous prompts via up/down arrows, and then goes back to the top of the list (current last unsent prompt), the unsent prompt was deleted, with this update the current unsent prompt is still visible and accessible. ([see PR](https://github.com/aws/mynah-ui/pull/198))
2. In VSCode and JetBrains, we fix the way code attachments are shown (when navigating to previous prompts which have a code attachment) by removing \``` at the beginning and end of the code snippets and potentially avoiding any replacement of the first instance of \~~~~~~~~~~ in the code snippet ([see PR](https://github.com/aws/mynah-ui/pull/200))

A visual example for the second issue:
**Original code attachment**
```
void main() {
  print("~~~~~~~~~~");
  print("Hello World");
  print("Hello World");
}
```
**Rendering before**
```
` ` `
void main() {
  print("");
  print("Hello World");
  print("Hello World");
}
` ` `
```

**Rendering after**
```
void main() {
  print("~~~~~~~~~~");
  print("Hello World");
  print("Hello World");
}
```



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
