### PR TITLE
feat: add public destroy command for resetting mynah ui state

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -27,6 +27,7 @@ mynahUI.notify(...);
 mynahUI.showCustomForm(...);
 mynahUI.updateTabDefaults(...);
 mynahUI.toggleSplashLoader(...);
+mynahUI.destroy();
 ```
 
 <p><br/></p>
@@ -537,3 +538,11 @@ mynahUI.toggleSplashLoader(true, 'Initializing');
 <p align="center">
   <img src="./img/splashLoader.png" alt="mainTitle" style="max-width:500px; width:100%;border: 1px solid #e0e0e0;">
 </p>
+
+# Destroy Mynah UI State (`destroy`)
+
+You can use this method to tear down the existing mynah ui state. This is useful if you want to run several tests on fresh instances of Mynah UI
+
+```typescript
+mynahUI.destroy()
+```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -541,8 +541,8 @@ mynahUI.toggleSplashLoader(true, 'Initializing');
 
 # Destroy Mynah UI State (`destroy`)
 
-You can use this method to tear down the existing mynah ui state. This is useful if you want to run several tests on fresh instances of Mynah UI
+You can use this method to tear down the existing Mynah UI state. This is useful if you want to run several tests on fresh instances of Mynah UI.
 
 ```typescript
-mynahUI.destroy()
+mynahUI.destroy();
 ```

--- a/src/helper/config.ts
+++ b/src/helper/config.ts
@@ -82,7 +82,7 @@ const configDefaults: ConfigFullModel = {
   },
 };
 export class Config {
-  private static instance: Config;
+  private static instance: Config | undefined;
   public config: ConfigFullModel;
   private constructor (config?: Partial<ConfigModel>) {
     this.config = {
@@ -127,4 +127,8 @@ export class Config {
 
     return Config.instance;
   }
+
+  public destroy = (): void => {
+    Config.instance = undefined;
+  };
 }

--- a/src/helper/dom.ts
+++ b/src/helper/dom.ts
@@ -76,7 +76,7 @@ export interface ExtendedHTMLElement extends HTMLInputElement {
 }
 
 export class DomBuilder {
-  private static instance: DomBuilder;
+  private static instance: DomBuilder | undefined;
   private rootFocus: boolean;
   root: ExtendedHTMLElement;
   private portals: Record<string, ExtendedHTMLElement> = {};
@@ -338,6 +338,10 @@ export class DomBuilder {
         delete this.portals[portalName];
       }
     });
+  };
+
+  destroy = (): void => {
+    DomBuilder.instance = undefined;
   };
 }
 

--- a/src/helper/events.ts
+++ b/src/helper/events.ts
@@ -14,7 +14,7 @@ export const cancelEvent = (event: Event): boolean => {
 };
 
 export class MynahUIGlobalEvents {
-  private static instance: MynahUIGlobalEvents;
+  private static instance: MynahUIGlobalEvents | undefined;
   private readonly listeners: Record<MynahEventNames, Record<string, (value?: any) => void>>;
 
   private constructor () {
@@ -65,5 +65,9 @@ export class MynahUIGlobalEvents {
         this.listeners[eventKey][listenerId](data);
       });
     }
+  };
+
+  public destroy = (): void => {
+    MynahUIGlobalEvents.instance = undefined;
   };
 }

--- a/src/helper/tabs-store.ts
+++ b/src/helper/tabs-store.ts
@@ -28,7 +28,7 @@ export class EmptyMynahUITabsStoreModel {
   }
 }
 export class MynahUITabsStore {
-  private static instance: MynahUITabsStore;
+  private static instance: MynahUITabsStore | undefined;
   private readonly subscriptions: TabStoreSubscription = {
     add: {},
     remove: {},
@@ -239,5 +239,9 @@ export class MynahUITabsStore {
         ...defaults.store
       }
     };
+  };
+
+  public destroy = (): void => {
+    MynahUITabsStore.instance = undefined;
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -867,6 +867,7 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
   };
 
   public destroy = (): void => {
+    Config.getInstance().destroy();
     MynahUITabsStore.getInstance().destroy();
     MynahUIGlobalEvents.getInstance().destroy();
     DomBuilder.getInstance().destroy();

--- a/src/main.ts
+++ b/src/main.ts
@@ -865,4 +865,10 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
       }
     });
   };
+
+  public destroy = (): void => {
+    MynahUITabsStore.getInstance().destroy();
+    MynahUIGlobalEvents.getInstance().destroy();
+    DomBuilder.getInstance().destroy();
+  };
 }


### PR DESCRIPTION
## Problem
When running e2e tests in vscode against mynah ui you have two options:
1. Create one mynah ui instance for all the subsequent tests, but this doesn't allow you to test specific functionality (e.g. the welcome page in VSCode shows up 3 times)
2. Create one mynah ui instance per test, but since mynah ui uses singletons and the module has been initialized already, its not actually providing a fresh state causing multiple extra events to be sent that shouldn't be

## Solution
Add a `destroy` method for resetting all the singletons back to their initial state. This allows you to create a fresh mynah ui instance in every test

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
