### PR TITLE
feat: up/down arrow navigation now only triggers when cursor is at the start or end of multiline inputs

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -324,6 +324,26 @@ export class ChatPromptInput {
           this.quickPickOpen = true;
         }
       } else if (navigationalKeys.includes(e.key)) {
+        const inputText = this.promptTextInput.getTextInputValue();
+        const cursorPosition = this.promptTextInput.getCursorPos();
+
+        const textBeforeCursor = inputText.substring(0, cursorPosition);
+        const textAfterCursor = inputText.substring(cursorPosition);
+
+        // Check if cursor is on the first line
+        const isFirstLine = !textBeforeCursor.includes('\n');
+
+        // Check if cursor is on the last line
+        const isLastLine = !textAfterCursor.includes('\n');
+
+        // Only allow up/down arrow navigation when user reaches the end of multiline input
+        if (e.key === KeyMap.ARROW_UP && !isFirstLine) {
+          return;
+        }
+        if (e.key === KeyMap.ARROW_DOWN && !isLastLine) {
+          return;
+        }
+
         if (this.userPromptHistoryIndex === -1 || this.userPromptHistoryIndex === this.userPromptHistory.length) {
           this.lastUnsentUserPrompt = {
             inputText: this.promptTextInput.getTextInputValue(),


### PR DESCRIPTION
## Problem
If there is multiline text in prompt field, it is not possible to navigate to upper lines by using app arrow, it triggers historical navigation.

## Solution
When there is text in the prompt field which is more than 1 line, until user approaches to the first line, keep the default behavior of the arrow keys.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
