### PR TITLE
fix: dev script also installs packages in ui-tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "watch:web": "run-p watch watch:example serve:example",
         "serve:example": "live-server --port=9000 example/dist",
         "start:example": "cd ./example && npm install && npm run build && cd .. && npm run watch:web",
-        "dev": "npm run clean && npm install && npm run build && npm run start:example",
+        "dev": "npm ci && npm run build && cd ./ui-tests && npm install && cd .. && npm run start:example",
         "lint-fix": "npx eslint \"./**\" --fix",
         "lint": "npx eslint \"./**\"",
         "format:check": "npx prettier --check .",


### PR DESCRIPTION
## Problem
Packages were not installed in `ui-tests` when running dev script, which gave import errors after cleaning and rebuilding the main package.

## Solution
Also `cd` into the `ui-tests` and run an `npm install`.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests (NA)
~- [ ] I have tested this change on VSCode~
~- [ ] I have tested this change on JetBrains~

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
