### PR TITLE
fix: don't show context menu when max input lenght is 0

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -296,7 +296,7 @@ export class ChatPromptInput {
         this.sendPrompt();
       } else if (
         (this.selectedCommand === '' && e.key === KeyMap.SLASH && this.promptTextInput.getTextInputValue() === '') ||
-        (e.key === KeyMap.AT)
+        (e.key === KeyMap.AT && this.promptTextInput.promptTextInputMaxLength > 0)
       ) {
         this.quickPickType = e.key === KeyMap.AT ? 'context' : 'quick-action';
         this.quickPickItemGroups = this.quickPickType === 'context' ? quickPickContextItems : quickPickCommandItems;


### PR DESCRIPTION
## Problem
During the command confirmation step, users can still type @ to open the context suggestion menu. The @ itself does not get typed into the text area, but the overlay menu still opens.

## Solution
The context menu does not open when max length of the prompt input is `0`.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
