### PR TITLE
Added cursor position check before running prompt history trigger

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -331,15 +331,16 @@ export class ChatPromptInput {
           };
         }
 
-        this.clearTextArea();
-
         if (this.userPromptHistoryIndex === -1) {
           this.userPromptHistoryIndex = this.userPromptHistory.length;
         }
 
-        if (e.key === KeyMap.ARROW_UP) {
+        const cursorLine = this.promptTextInput.getCursorLine();
+        if (e.key === KeyMap.ARROW_UP && cursorLine.cursorLine <= 1) {
+          // Check if the cursor is on the first line or not
           this.userPromptHistoryIndex = Math.max(0, this.userPromptHistoryIndex - 1);
-        } else if (e.key === KeyMap.ARROW_DOWN) {
+        } else if (e.key === KeyMap.ARROW_DOWN && cursorLine.cursorLine >= cursorLine.totalLines) {
+          // Check if the cursor is on the last line or not
           this.userPromptHistoryIndex = Math.min(this.userPromptHistory.length, this.userPromptHistoryIndex + 1);
         }
 

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -127,6 +127,11 @@
                     color: rgba(0, 0, 0, 0);
                     position: relative;
                     z-index: 150;
+                    > span.cursor {
+                        max-width: 0;
+                        line-height: inherit;
+                        display: inline;
+                    }
                     > span.context {
                         position: relative;
                         color: var(--mynah-color-button-reverse);


### PR DESCRIPTION
## Problem
- When using the up and down arrow keys to grab previous prompts like in a terminal, it is not possible to navigate through the text anymore. It should only trigger the historical previous/next prompt actions when on the first and last lines
- Cursor jumps to text end after up and down arrow actions even if there is no previous prompt available.

## Solution
- Added current cursor line check before triggering historical prompt calls.
- Fixed unnecessary cleanup which causes a cursor jump to the end.

## Tests
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
