### PR TITLE
Add additional backslash to escapedPrompt

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -679,7 +679,7 @@ export class ChatPromptInput {
           context.push(match);
         }
         return `**${match}**`;
-      }));
+      })).replace(/\\/g, '\\\\');
 
       const promptData: {tabId: string; prompt: ChatPrompt} = {
         tabId: this.props.tabId,

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -679,7 +679,7 @@ export class ChatPromptInput {
           context.push(match);
         }
         return `**${match}**`;
-      })).replace(/\\/g, '\\\\');
+      })).replace(/\\(?![^`]*`[^`]*(?:`[^`]*`[^`]*)*$)/g, '\\\\');
 
       const promptData: {tabId: string; prompt: ChatPrompt} = {
         tabId: this.props.tabId,


### PR DESCRIPTION
## Problem
Chat prompts with a sequence of multiple backslashes will result in backslashes to be gone in the prompt card

Input example:
```
Make a regex that get '\\(' occurrences on string

Make a regex that get \\( occurrences on string

Make a regex that get\\( occurrences on string

Make a regex that get \\(occurrences on string

Make a regex that get '\\\(' occurrences on string

Make a regex that get '\\' occurrences on string

Make a regex that get \\ occurrences on string

Make a regex that get \' occurrences on string

Make a regex that get '\ occurrences on string
```

Result:
![Screenshot 2024-12-24 at 15 37 00](https://github.com/user-attachments/assets/1f5f8421-ccff-4978-99ae-f1a516ae7f60)


## Solution
Add regex logic in the escaped prompt to add an additional backslash on sequences of backslashes

Result:
![Screenshot 2024-12-24 at 15 35 24](https://github.com/user-attachments/assets/f97a4297-5af2-4afe-9280-853d22d0772e)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
