### PR TITLE
test: added e2e test for checking first/last line in prompt navigation

### DIFF
--- a/ui-tests/__test__/flows/navigate-prompts/navigate-prompts-first-last-line-check.ts
+++ b/ui-tests/__test__/flows/navigate-prompts/navigate-prompts-first-last-line-check.ts
@@ -1,0 +1,38 @@
+import { Page } from 'playwright/test';
+import { getSelector, waitForAnimationEnd } from '../../helpers';
+import testIds from '../../../../src/helper/test-ids';
+import { closeTab } from '../close-tab';
+import { openNewTab } from '../open-new-tab';
+
+export const navigatePromptsFirstLastLineCheck = async (page: Page, skipScreenshots?: boolean): Promise<void> => {
+  await closeTab(page, false, true);
+  await openNewTab(page, false, true);
+
+  const promptInput = page.locator(getSelector(testIds.prompt.input));
+  const sendButton = page.locator(getSelector(testIds.prompt.send));
+
+  await promptInput.fill('This is the first user prompt');
+  await sendButton.click();
+  await waitForAnimationEnd(page);
+
+  await promptInput.fill('This is the second user prompt\nIt spans two separate lines.');
+  await waitForAnimationEnd(page);
+
+  // The input should start as the input with two lines
+  expect(await promptInput.inputValue()).toBe('This is the second user prompt\nIt spans two separate lines.');
+
+  // Input should remain the same and the cursor position should move to the first line
+  await promptInput.press('ArrowUp');
+  await waitForAnimationEnd(page);
+  expect(await promptInput.inputValue()).toBe('This is the second user prompt\nIt spans two separate lines.');
+
+  // Now that we're in the first line, it should navigate to the first user prompt
+  await promptInput.press('ArrowUp');
+  await waitForAnimationEnd(page);
+  expect(await promptInput.inputValue()).toBe('This is the first user prompt');
+
+  // Given that this input only has one line, we should be able to go down to prompt 2 immediately again
+  await promptInput.press('ArrowDown');
+  await waitForAnimationEnd(page);
+  expect(await promptInput.inputValue()).toBe('This is the second user prompt\nIt spans two separate lines.');
+};

--- a/ui-tests/__test__/main.spec.ts
+++ b/ui-tests/__test__/main.spec.ts
@@ -41,6 +41,7 @@ import { submitFeedbackForm } from './flows/feedback-form/submit-feedback-form';
 import { stayOnCurrentPrompt } from './flows/navigate-prompts/stay-on-current-prompt';
 import { navigateBackToCurrentPrompt } from './flows/navigate-prompts/navigate-back-to-current-prompt';
 import { navigateBackToCurrentPromptWithCodeAttachment } from './flows/navigate-prompts/navigate-back-to-current-prompt-with-code-attachment';
+import { navigatePromptsFirstLastLineCheck } from './flows/navigate-prompts/navigate-prompts-first-last-line-check';
 
 describe('Open MynahUI', () => {
   beforeEach(async () => {
@@ -232,6 +233,9 @@ describe('Open MynahUI', () => {
     25000);
     it('should navigate down to current empty prompt', async () => {
       await navigatePromptsToEmpty(page);
+    });
+    it('should navigate up/down only if on first/last line', async () => {
+      await navigatePromptsFirstLastLineCheck(page);
     });
 
     it('should stay on current prompt', async () => {


### PR DESCRIPTION
## Problem
Recently, the up/down arrow prompt navigation has been updated to only trigger when the cursor is on the first or last line. This was not being tested yet.

## Solution
Added an E2E test which covers this test case.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests (NA)
~- [ ] I have tested this change on VSCode~
~- [ ] I have tested this change on JetBrains~

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
