### PR TITLE
refactor: extracted prompt texts in new test into variables

### DIFF
--- a/ui-tests/__test__/flows/navigate-prompts/navigate-prompts-first-last-line-check.ts
+++ b/ui-tests/__test__/flows/navigate-prompts/navigate-prompts-first-last-line-check.ts
@@ -8,31 +8,34 @@ export const navigatePromptsFirstLastLineCheck = async (page: Page, skipScreensh
   await closeTab(page, false, true);
   await openNewTab(page, false, true);
 
+  const firstPrompt = 'This is the first user prompt';
+  const secondPrompt = 'This is the second user prompt\nIt spans two separate lines.';
+
   const promptInput = page.locator(getSelector(testIds.prompt.input));
   const sendButton = page.locator(getSelector(testIds.prompt.send));
 
-  await promptInput.fill('This is the first user prompt');
+  await promptInput.fill(firstPrompt);
   await sendButton.click();
   await waitForAnimationEnd(page);
 
-  await promptInput.fill('This is the second user prompt\nIt spans two separate lines.');
+  await promptInput.fill(secondPrompt);
   await waitForAnimationEnd(page);
 
   // The input should start as the input with two lines
-  expect(await promptInput.inputValue()).toBe('This is the second user prompt\nIt spans two separate lines.');
+  expect(await promptInput.inputValue()).toBe(secondPrompt);
 
   // Input should remain the same and the cursor position should move to the first line
   await promptInput.press('ArrowUp');
   await waitForAnimationEnd(page);
-  expect(await promptInput.inputValue()).toBe('This is the second user prompt\nIt spans two separate lines.');
+  expect(await promptInput.inputValue()).toBe(secondPrompt);
 
   // Now that we're in the first line, it should navigate to the first user prompt
   await promptInput.press('ArrowUp');
   await waitForAnimationEnd(page);
-  expect(await promptInput.inputValue()).toBe('This is the first user prompt');
+  expect(await promptInput.inputValue()).toBe(firstPrompt);
 
   // Given that this input only has one line, we should be able to go down to prompt 2 immediately again
   await promptInput.press('ArrowDown');
   await waitForAnimationEnd(page);
-  expect(await promptInput.inputValue()).toBe('This is the second user prompt\nIt spans two separate lines.');
+  expect(await promptInput.inputValue()).toBe(secondPrompt);
 };


### PR DESCRIPTION
## Problem
Noticed a case of duplicated code strings in the e2e test I added yesterday.

## Solution
Extracted the reusable strings into variables.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
