### PR TITLE
Dogusata/fix cursor position reset after history item set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.21.3",
+    "version": "4.21.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.21.3",
+            "version": "4.21.5",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.21.4",
+    "version": "4.21.5",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -346,14 +346,10 @@ export class ChatPromptInput {
 
         let codeAttachment = '';
         if (this.userPromptHistoryIndex === this.userPromptHistory.length) {
-          MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).updateStore({
-            promptInputText: this.lastUnsentUserPrompt.inputText ?? '',
-          });
+          this.promptTextInput.updateTextInputValue(this.lastUnsentUserPrompt.inputText ?? '');
           codeAttachment = this.lastUnsentUserPrompt.codeAttachment ?? '';
         } else {
-          MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).updateStore({
-            promptInputText: this.userPromptHistory[this.userPromptHistoryIndex].inputText,
-          });
+          this.promptTextInput.updateTextInputValue(this.userPromptHistory[this.userPromptHistoryIndex].inputText);
           codeAttachment = this.userPromptHistory[this.userPromptHistoryIndex].codeAttachment ?? '';
         }
         codeAttachment = codeAttachment.trim();
@@ -371,7 +367,9 @@ export class ChatPromptInput {
               .replace(/```$/, '')
               .trim();
           }
-          this.addAttachment(codeAttachment, 'code');
+          this.promptAttachment.updateAttachment(codeAttachment, 'code');
+        } else {
+          this.promptAttachment.clear();
         }
       }
     } else {


### PR DESCRIPTION
## Problem
- When you use the cursor to navigate between the older prompts, after the prompt is set, the cursor position resets itself to end of the text after 100-500ms.
- When there is a code attachment in the historical prompts, it was not possible to navigate anymore directly with up/down arrow. Also, the code attachment remains on screen.

## Solution
- Setting the prompt field text through global store was not necessary, since it is an async process. Instead we have the `promptTextInput` component already in hand, which has the `updateText` method.
- Setting the code attachment through global store was not necessary since it is an async process . Instead we have the `promptAttachment` component already in hand, which has the `updateAttachment` and `clear` methods. **However,** it might seem like making it through the data store can also do the checks for max length with prompt text and the attachment. **BUT** since users cannot send prompts without this check it means that the historical prompts already being checked before they are sent. **Again, only updating the component is enough**.
- Else state was missing for the case if there is no attachment on the previous or last not sent prompts. If there is no attachment, it should clear the code attachment field.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
