### PR TITLE
fix: Linkify skips double square brackets for text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.22.0",
+    "version": "4.22.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.22.0",
+            "version": "4.22.1",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.22.0",
+    "version": "4.22.1",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -277,7 +277,7 @@ ${item.task ? `<input ${item.checked === true ? 'checked' : ''} disabled type="c
 ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) as string}
 </li>`,
         link: (token) => {
-          const pattern = /^\[([^\]]+)\]\(([^)]+)\)$/;
+          const pattern = /^\[(?:\[([^\]]+)\]|([^\]]+))\]\(([^)]+)\)$/;
           // Expect raw formatted only in [TEXT](URL)
           if (!pattern.test(token.raw)) {
             return token.href;


### PR DESCRIPTION
## Problem
The latest linkify [handler fix](https://github.com/aws/mynah-ui/pull/226) introduced a bug which the citations are not visible as clickable numbered links

<img width="663" alt="Screenshot 2025-02-03 at 13 01 43" src="https://github.com/user-attachments/assets/80ba1393-9c37-4081-8888-09e8e3bdc0bc" />


## Solution
Updated the pattern which checks the links are valid to also accept `[[1]](LINK)` format which Q returns as this. (Double square brackets)

## Tests
- [X] I have tested this change on VSCode
- [X] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
