### PR TITLE
Skip Slack message on draft PRs

### DIFF
--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -2,6 +2,7 @@ name: Check Lint, Tests and Build
 on:
   pull_request:
     branches: [main, feature/*, fix/*]
+    types: [review_requested, ready_for_review]
 jobs:
   notify:
     name: Slack notification

--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -2,11 +2,12 @@ name: Check Lint, Tests and Build
 on:
   pull_request:
     branches: [main, feature/*, fix/*]
-    types: [review_requested, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
 jobs:
   notify:
     name: Slack notification
     runs-on: [ubuntu-latest]
+    if: !github.event.pull_request.draft
     steps:
       - name: Post message
         uses: slackapi/slack-github-action@v1.25.0

--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -5,9 +5,9 @@ on:
     types: [opened, reopened, ready_for_review, synchronize]
 jobs:
   notify:
+    if: !github.event.pull_request.draft
     name: Slack notification
     runs-on: [ubuntu-latest]
-    if: !github.event.pull_request.draft
     steps:
       - name: Post message
         uses: slackapi/slack-github-action@v1.25.0

--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, ready_for_review, synchronize]
 jobs:
   notify:
-    if: !github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     name: Slack notification
     runs-on: [ubuntu-latest]
     steps:


### PR DESCRIPTION
## Problem
Messages to Slack were being sent through the GitHub CI workflow, even for Draft PRs.

## Solution
Filter to just run on non-draft PRs.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
