### PR TITLE
Added conversation persistence methods on client side

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -323,6 +323,21 @@ default: `false`
 
 ---
 
+# `autoSave`
+Whether to run the `MynahUI.save()` function by default on a couple of predefined events:
+- Whenever a new tab is created
+- Whenever a tab is closed
+- Whenever a tab is selected
+- Whenever any chatItem is added to a chat
+
+This will ensure a very basic saving behavior, but is not optimized nor specialized for custom saving implementations. You can extend the default saving behavior by adding `mynahUI.save()` to specified event handlers in the `MynahUI` constructor.
+
+**Note: if `persistConversations` is set to false, `autoSave` naturally also does not have any effect.**
+
+default: `false`
+
+---
+
 ## `codeInsertToCursorEnabled` and `codeCopyToClipboardEnabled` (default: true)
 These two parameters allow you to make copy and insert buttons disabled system wide. If you want to disable it specifically for a message you can do it through `ChatItem` object. Please see [DATAMODEL Documentation](./DATAMODEL.md#codeinserttocursorenabled-and-codecopytoclipboardenabled-default-true).
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -320,6 +320,9 @@ default: `4096`
 # `persistConversations`
 Whether data of tabs should be persisted so that it can be loaded later. If disabled, the `MynahUI.save()` function will have no effect. When enabled, the `MynahUI.save()` function will either save to localStorage by default under the `mynah-ui-storage` key, or use custom saving behavior defined with the `onSave()` callback.
 
+> [!NOTE]
+> Make sure to take into account how different IDE windows e.g. could conflict by saving to the same location, causing possibly unexpected saving behavior.
+
 default: `false`
 
 ---

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -47,6 +47,7 @@ interface ConfigModel {
     }>;
     tabBarButtons?: TabBarMainAction[]; // Tab bar buttons will be shown on the right of the tab
     maxUserInput: number; // max number of chars for the input field
+    persistConversations: boolean, // whether to save conversations, by default in localStorage
     userInputLengthWarningThreshold: number; // The amount of characters in the input field necessary for the character limit warning to show
     codeInsertToCursorEnabled?: boolean; // show or hide copy buttons on code blocks system wide
     codeCopyToClipboardEnabled?: boolean; // show or hide insert to cursor buttons on code blocks system wide
@@ -312,6 +313,13 @@ Max number of chars user can insert into the prompt field. But, as might know yo
 **So beware that if you want 4000 chars exact, you need to give 4096 to the config.**
 
 default: `4096`
+
+---
+
+# `persistConversations`
+Whether data of tabs should be persisted so that it can be loaded later. If disabled, the `MynahUI.save()` function will have no effect. When enabled, the `MynahUI.save()` function will either save to localStorage by default under the `mynah-ui-storage` key, or use custom saving behavior defined with the `onSave()` callback.
+
+default: `false`
 
 ---
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -48,6 +48,7 @@ interface ConfigModel {
     tabBarButtons?: TabBarMainAction[]; // Tab bar buttons will be shown on the right of the tab
     maxUserInput: number; // max number of chars for the input field
     persistConversations: boolean, // whether to save conversations, by default in localStorage
+    autoSave: boolean, // whether to automatically trigger the save() function on tab creation / deletion / selection, and chatItem adding
     userInputLengthWarningThreshold: number; // The amount of characters in the input field necessary for the character limit warning to show
     codeInsertToCursorEnabled?: boolean; // show or hide copy buttons on code blocks system wide
     codeCopyToClipboardEnabled?: boolean; // show or hide insert to cursor buttons on code blocks system wide

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -11,6 +11,7 @@ export interface MynahUIProps {
     messageId: string,
     eventId?: string) => void;
   onReady?: () => void;
+  onSave?: (tabsData: MynahUITabStoreModel) => void;
   onFocusStateChanged?: (focusState: boolean) => void;
   onVote?: (
     tabId: string,
@@ -306,13 +307,29 @@ onReady: () => {
 
 ### `onFocusStateChanged`
 
-This event will be fired whenever user targets to MynahUI or wents away.
+This event will be fired whenever user targets to MynahUI or went away.
 
 ```typescript
 ...
 onFocusStateChanged: (focusState: boolean) => {
       console.log(`MynahUI is ${focusState ? 'focused' : 'not focused'}.`);
     };
+...
+```
+
+---
+
+### `onSave`
+
+This callback should be defined to override the default saving behavior for conversation persistance.
+By default, calling `MynahUI.save()` will save the tabsData to localStorage with the `mynah-ui-storage` key, as demonstrated below.
+
+```typescript
+...
+onSave: (tabsData: MynahUITabStoreModel) => {
+      console.log('Saving MynahUI!');
+      localStorage.setItem('mynah-ui-storage', JSON.stringify(tabsData));
+    },
 ...
 ```
 

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -12,6 +12,7 @@ import {
   ChatItem,
   MynahIcons,
   generateUID,
+  MynahUITabStoreModel,
 } from '@aws/mynah-ui';
 import { mynahUIDefaults } from './config';
 import { Log, LogClear } from './logger';
@@ -50,6 +51,8 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
   const connector = new Connector();
   let streamingMessageId: string | null;
   let showChatAvatars: boolean = false;
+
+  const persistedData = localStorage.getItem('mynah-ui-storage')
 
   const mynahUI = new MynahUI({
     splashScreenInitialStatus: {
@@ -111,11 +114,16 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
               icon: MynahIcons.CURSOR_INSERT,
               text: 'Insert code!',
             },
+            {
+              id: 'save',
+              icon: MynahIcons.ROCKET,
+              text: 'Save',
+            },
           ],
         },
       ],
     },
-    tabs: {
+    tabs: persistedData ? JSON.parse(persistedData) : {
       'tab-1': {
         isSelected: true,
         store: {
@@ -124,7 +132,11 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
         }
       },
     },
-    onFocusStateChanged: (focusState:boolean) => {
+    onSave: (tabsData: MynahUITabStoreModel) => {
+      Log('MynahUI save event triggered');
+      localStorage.setItem('mynah-ui-storage', JSON.stringify(tabsData))
+    },
+    onFocusStateChanged: (focusState: boolean) => {
       Log(`MynahUI focus state changed: <b>${focusState.toString()}</b>`);
     },
     onTabBarButtonClick: (tabId: string, buttonId: string) => {
@@ -170,6 +182,8 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
           ...mynahUIDefaults.store,
           ...welcomeScreenTabData.store
         });
+      } else if (buttonId === 'save') {
+        mynahUI.save();
       }
       Log(`Tab bar button clicked when tab ${tabId} is selected: <b>${buttonId}</b>`);
     },

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -68,6 +68,7 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
     },
     config: {
       maxTabs: 5,
+      persistConversations: true,
       maxTabsTooltipDuration: 5000,
       noMoreTabsTooltip: 'You can only open five conversation tabs at a time.',
       autoFocus: true,

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -69,6 +69,7 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
     config: {
       maxTabs: 5,
       persistConversations: true,
+      autoSave: true,
       maxTabsTooltipDuration: 5000,
       noMoreTabsTooltip: 'You can only open five conversation tabs at a time.',
       autoFocus: true,
@@ -430,6 +431,10 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
   setTimeout(()=>{
     mynahUI.toggleSplashLoader(false);
   }, 2750)
+
+  const onTest = () => {
+    mynahUI.save()
+  }
 
   const onChatPrompt = (tabId: string, prompt: ChatPrompt) => {
     if (prompt.command !== undefined && prompt.command.trim() !== '') {

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -470,10 +470,6 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
     mynahUI.toggleSplashLoader(false);
   }, 2750)
 
-  const onTest = () => {
-    mynahUI.save()
-  }
-
   const onChatPrompt = (tabId: string, prompt: ChatPrompt) => {
     if (prompt.command !== undefined && prompt.command.trim() !== '') {
       switch (prompt.command) {

--- a/src/helper/config.ts
+++ b/src/helper/config.ts
@@ -17,6 +17,7 @@ const configDefaults: ConfigFullModel = {
   userInputLengthWarningThreshold: 3500,
   maxUserInput: 4096,
   persistConversations: false,
+  autoSave: false,
   showPromptField: true,
   autoFocus: true,
   tabBarButtons: [],

--- a/src/helper/config.ts
+++ b/src/helper/config.ts
@@ -16,6 +16,7 @@ const configDefaults: ConfigFullModel = {
   maxTabs: 1000,
   userInputLengthWarningThreshold: 3500,
   maxUserInput: 4096,
+  persistConversations: false,
   showPromptField: true,
   autoFocus: true,
   tabBarButtons: [],

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,6 +100,7 @@ export interface MynahUIProps {
     messageId: string,
     eventId?: string) => void;
   onReady?: () => void;
+  onSave?: (tabsData: MynahUITabStoreModel) => void;
   onFocusStateChanged?: (focusState: boolean) => void;
   onVote?: (
     tabId: string,
@@ -420,7 +421,7 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
   };
 
   private readonly addGlobalListeners = (): void => {
-    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.CHAT_PROMPT, (data: {tabId: string; prompt: ChatPrompt}) => {
+    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.CHAT_PROMPT, (data: { tabId: string; prompt: ChatPrompt }) => {
       if (this.props.onChatPrompt !== undefined) {
         this.props.onChatPrompt(data.tabId, data.prompt, this.getUserEventId());
       }
@@ -479,7 +480,7 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
       }
     });
 
-    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.SHOW_MORE_WEB_RESULTS_CLICK, (data: {messageId: string}) => {
+    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.SHOW_MORE_WEB_RESULTS_CLICK, (data: { messageId: string }) => {
       if (this.props.onShowMoreWebResultsClick !== undefined) {
         this.props.onShowMoreWebResultsClick(
           MynahUITabsStore.getInstance().getSelectedTabId(),
@@ -616,13 +617,13 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
       }
     });
 
-    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.RESET_STORE, (data: {tabId: string}) => {
+    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.RESET_STORE, (data: { tabId: string }) => {
       if (this.props.onResetStore !== undefined) {
         this.props.onResetStore(data.tabId);
       }
     });
 
-    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.ROOT_FOCUS, (data: {focusState: boolean}) => {
+    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.ROOT_FOCUS, (data: { focusState: boolean }) => {
       this.props.onFocusStateChanged?.(data.focusState);
     });
 
@@ -813,6 +814,11 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
    * @returns string selectedTabId or undefined
    */
   public getAllTabs = (): MynahUITabStoreModel => MynahUITabsStore.getInstance().getAllTabs();
+
+  public save = (): void => {
+    const tabs = this.getAllTabs();
+    this.props.onSave?.(tabs);
+  };
 
   /**
    * Toggles the visibility of the splash loader screen

--- a/src/main.ts
+++ b/src/main.ts
@@ -341,6 +341,9 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
           if (this.props.onTabChange !== undefined) {
             this.props.onTabChange(selectedTabId, this.getUserEventId());
           }
+          if ((this.props.config?.autoSave) ?? false) {
+            this.save();
+          }
         },
         maxTabsTooltipDuration: Config.getInstance().config.maxTabsTooltipDuration,
         noMoreTabsTooltip: Config.getInstance().config.noMoreTabsTooltip,
@@ -388,6 +391,9 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
       if (this.props.onTabAdd !== undefined) {
         this.props.onTabAdd(tabId, this.getUserEventId());
       }
+      if ((this.props.config?.autoSave) ?? false) {
+        this.save();
+      }
     });
     MynahUITabsStore.getInstance().addListener('remove', (tabId: string) => {
       this.chatWrappers[tabId].render.remove();
@@ -395,6 +401,9 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
       delete this.chatWrappers[tabId];
       if (this.props.onTabRemove !== undefined) {
         this.props.onTabRemove(tabId, this.getUserEventId());
+      }
+      if ((this.props.config?.autoSave) ?? false) {
+        this.save();
       }
     });
 
@@ -692,6 +701,10 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
           chatItem
         ]
       });
+
+      if ((this.props.config?.autoSave) ?? false) {
+        this.save();
+      }
     }
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -820,6 +820,9 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
    * If not, the default saving behavior of saving to localStorage will be enforced.
    */
   public save = (): void => {
+    if (!((this.props.config?.persistConversations) ?? false)) {
+      return;
+    }
     const tabs = this.getAllTabs();
     if (this.props.onSave !== undefined) {
       this.props.onSave(tabs);

--- a/src/main.ts
+++ b/src/main.ts
@@ -815,9 +815,18 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
    */
   public getAllTabs = (): MynahUITabStoreModel => MynahUITabsStore.getInstance().getAllTabs();
 
+  /**
+   * Calls the onSave callback if it is defined.
+   * If not, the default saving behavior of saving to localStorage will be enforced.
+   */
   public save = (): void => {
     const tabs = this.getAllTabs();
-    this.props.onSave?.(tabs);
+    if (this.props.onSave !== undefined) {
+      this.props.onSave(tabs);
+    } else {
+      // By default, save to localStorage
+      localStorage.setItem('mynah-ui-storage', JSON.stringify(tabs));
+    }
   };
 
   /**

--- a/src/static.ts
+++ b/src/static.ts
@@ -527,6 +527,7 @@ export interface ConfigOptions {
   autoFocus: boolean;
   maxUserInput: number;
   persistConversations?: boolean;
+  autoSave?: boolean;
   userInputLengthWarningThreshold: number;
   codeBlockActions?: CodeBlockActions;
   codeInsertToCursorEnabled?: boolean;

--- a/src/static.ts
+++ b/src/static.ts
@@ -526,6 +526,7 @@ export interface ConfigOptions {
   showPromptField: boolean;
   autoFocus: boolean;
   maxUserInput: number;
+  persistConversations?: boolean;
   userInputLengthWarningThreshold: number;
   codeBlockActions?: CodeBlockActions;
   codeInsertToCursorEnabled?: boolean;


### PR DESCRIPTION
## Problem
There was no (documented) way to save and load conversations / tabs on the client side within MynahUI.

## Solution
Added config options to persist the chat interactions (across all tabs) locally with an overridable `save()` function. Also added and autoSave config option, which will save in 4 default cases (see documentation).

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
