### PR TITLE
Jurredr/falcon filelist updates

### DIFF
--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -885,6 +885,8 @@ interface ChatItemContent {
     rootFolderTitle?: string;
     filePaths?: string[];
     deletedFiles?: string[];
+    collapsedByDefault?: boolean;
+    hideFileCount?: boolean;
     actions?: Record<string, FileNodeAction[]>;
     details?: Record<string, TreeNodeDetails>;
   } | null;
@@ -1770,6 +1772,8 @@ mynahUI.addChatItem(tabId, {
     deletedFiles: ['src/devfile.yaml'],
     // fileTreeTitle: "Custom file tree card title";
     // rootFolderTitle: "Custom root folder title";
+    // collapsedByDefault: true // Collapse the root folder by default
+    // hideFileCount: true // Hide the file counter next to folders
     actions: {
       'src/App.tsx': [
         {

--- a/src/components/chat-item/chat-item-card.ts
+++ b/src/components/chat-item/chat-item-card.ts
@@ -345,6 +345,8 @@ export class ChatItemCard {
         messageId: this.props.chatItem.messageId ?? '',
         cardTitle: this.props.chatItem.fileList.fileTreeTitle,
         rootTitle: this.props.chatItem.fileList.rootFolderTitle,
+        hideFileCount: this.props.chatItem.fileList.hideFileCount ?? false,
+        collapsedByDefault: this.props.chatItem.fileList.collapsedByDefault ?? false,
         files: filePaths,
         deletedFiles,
         actions,

--- a/src/components/chat-item/chat-item-tree-view-wrapper.ts
+++ b/src/components/chat-item/chat-item-tree-view-wrapper.ts
@@ -23,6 +23,8 @@ export interface ChatItemTreeViewWrapperProps {
   deletedFiles: string[];
   actions?: Record<string, FileNodeAction[]>;
   details?: Record<string, TreeNodeDetails>;
+  hideFileCount?: boolean;
+  collapsedByDefault?: boolean;
   referenceSuggestionLabel: string;
   references: ReferenceTrackerInformation[];
 }
@@ -52,6 +54,8 @@ export class ChatItemTreeViewWrapper {
         messageId: props.messageId,
         tabId: props.tabId,
         node: fileListToTree(props.files, props.deletedFiles, props.actions, props.details, props.rootTitle),
+        hideFileCount: props.hideFileCount,
+        collapsedByDefault: props.collapsedByDefault
       }).render;
 
     this.render = DomBuilder.getInstance().build({

--- a/src/components/chat-item/chat-item-tree-view.ts
+++ b/src/components/chat-item/chat-item-tree-view.ts
@@ -12,6 +12,8 @@ export interface ChatItemTreeViewProps {
   depth?: number;
   tabId: string;
   messageId: string;
+  hideFileCount?: boolean;
+  collapsedByDefault?: boolean;
 }
 
 export class ChatItemTreeView {
@@ -20,13 +22,15 @@ export class ChatItemTreeView {
   private readonly depth: number;
   private readonly tabId: string;
   private readonly messageId: string;
+  private readonly hideFileCount: boolean;
   render: ExtendedHTMLElement;
 
   constructor (props: ChatItemTreeViewProps) {
     this.node = props.node;
     this.tabId = props.tabId;
     this.messageId = props.messageId;
-    this.isOpen = true;
+    this.hideFileCount = props.hideFileCount ?? false;
+    this.isOpen = !(props.collapsedByDefault ?? false);
     this.depth = props.depth ?? 0;
     this.render = DomBuilder.getInstance().build({
       type: 'div',
@@ -57,7 +61,7 @@ export class ChatItemTreeView {
         DomBuilder.getInstance().build({
           type: 'div',
           classNames: [ 'mynah-chat-item-pull-request-item' ],
-          children: [ new ChatItemTreeView({ node: childNode, depth: this.depth + 1, tabId: this.tabId, messageId: this.messageId }).render ],
+          children: [ new ChatItemTreeView({ node: childNode, depth: this.depth + 1, tabId: this.tabId, hideFileCount: this.hideFileCount, messageId: this.messageId }).render ],
         })
       )
       : [];
@@ -80,11 +84,13 @@ export class ChatItemTreeView {
             type: 'span',
             children: [ this.node.name ]
           },
-          {
-            type: 'span',
-            classNames: [ 'mynah-chat-item-tree-view-button-weak-title' ],
-            children: [ `${this.node.children.length} ${Config.getInstance().config.texts.files}` ]
-          }
+          ...(this.hideFileCount
+            ? []
+            : [ {
+                type: 'span',
+                classNames: [ 'mynah-chat-item-tree-view-button-weak-title' ],
+                children: [ `${this.node.children.length} ${Config.getInstance().config.texts.files}` ]
+              } ])
         ]
       }),
       primary: false,

--- a/src/static.ts
+++ b/src/static.ts
@@ -269,6 +269,8 @@ export interface ChatItemContent {
     rootFolderTitle?: string;
     filePaths?: string[];
     deletedFiles?: string[];
+    collapsedByDefault?: boolean;
+    hideFileCount?: boolean;
     actions?: Record<string, FileNodeAction[]>;
     details?: Record<string, TreeNodeDetails>;
   } | null;


### PR DESCRIPTION
## Problem
The FileTree component should support hiding the amount of files next to folders and showing the root folder collapsed.

## Solution
Add two new props, to conditionally collapse the root folder and render file counts.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
