### PR TITLE
EXPERIMENTAL: file tree with overflow-y scroll instead of truncation

### DIFF
--- a/src/styles/components/chat/_chat-item-tree-view.scss
+++ b/src/styles/components/chat/_chat-item-tree-view.scss
@@ -73,7 +73,6 @@
             }
 
             .mynah-chat-item-pull-request-item {
-                // width: 100%;
                 box-sizing: border-box;
             }
         }

--- a/src/styles/components/chat/_chat-item-tree-view.scss
+++ b/src/styles/components/chat/_chat-item-tree-view.scss
@@ -14,7 +14,6 @@
         position: relative;
         border-radius: var(--mynah-input-radius);
         border: var(--mynah-border-width) solid var(--mynah-color-border-default);
-        overflow: hidden;
 
         > .mynah-chat-item-tree-view-wrapper-title {
             display: flex;
@@ -45,14 +44,11 @@
 
         > .mynah-chat-item-tree-view {
             padding: var(--mynah-sizing-1);
+            overflow-y: scroll;
         }
 
         .mynah-chat-item-tree-view {
-            overflow: hidden;
             box-sizing: border-box;
-            width: 100%;
-            overflow-y: hidden;
-            overflow-x: auto;
             display: flex;
             flex-flow: column nowrap;
             justify-content: flex-start;
@@ -77,7 +73,7 @@
             }
 
             .mynah-chat-item-pull-request-item {
-                width: 100%;
+                // width: 100%;
                 box-sizing: border-box;
             }
         }
@@ -88,9 +84,8 @@
             justify-content: space-between;
             align-items: center;
             gap: var(--mynah-sizing-2);
-            overflow: hidden;
+            overflow-y: hidden;
             cursor: pointer;
-            width: calc(100% - var(--mynah-sizing-4));
             padding: calc(3 * var(--mynah-sizing-half));
             position: relative;
             box-sizing: content-box;
@@ -185,13 +180,10 @@
                 z-index: 10;
                 flex: 1;
                 flex-shrink: 2;
-                overflow: hidden;
 
                 > .mynah-chat-item-tree-view-file-item-details-text {
-                    overflow: hidden;
                     flex: 1;
                     white-space: nowrap;
-                    text-overflow: ellipsis;
                 }
             }
 
@@ -240,8 +232,6 @@
                 justify-content: flex-start;
                 align-items: center;
                 gap: var(--mynah-sizing-1);
-                max-width: 100%;
-                overflow: hidden;
                 z-index: 10;
                 flex-shrink: 0.01;
 
@@ -251,10 +241,7 @@
                 }
 
                 > span {
-                    text-overflow: ellipsis;
-                    overflow: hidden;
                     white-space: nowrap;
-                    max-width: 100%;
                 }
             }
 


### PR DESCRIPTION
## Problem
Allow file trees to scroll through overflow horizontally, instead of truncating text. As a preparation for larger file trees. Not sure if this is the way to go, and also not thoroughly tested, so highly experimental for now.

https://github.com/user-attachments/assets/e029a969-ffdc-47f7-aab1-591d5805e3d2


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
