### PR TITLE
Fixed form validator bug; not taking non-mandatory empty fields into account

### DIFF
--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -574,7 +574,7 @@ _To send the form, mandatory items should be filled._`,
             id: 'name',
             type: 'textinput',
             mandatory: true,
-            title: `Name (should contain "amazonq" or "aws" in the string)`,
+            title: `Name (should contain "amazonq" and "aws" in the string)`,
             validationPatterns: {
                 operator: 'and',
                 patterns: [{

--- a/src/components/chat-item/chat-item-form-items.ts
+++ b/src/components/chat-item/chat-item-form-items.ts
@@ -103,6 +103,7 @@ export class ChatItemFormItemsWrapper {
               description,
               fireModifierAndEnterKeyPress,
               value,
+              mandatory: chatItemOption.mandatory,
               validationPatterns: chatItemOption.validationPatterns,
               placeholder: chatItemOption.placeholder,
               ...(this.getValidationHandler(chatItemOption))
@@ -115,6 +116,7 @@ export class ChatItemFormItemsWrapper {
               description,
               fireModifierAndEnterKeyPress,
               value,
+              mandatory: chatItemOption.mandatory,
               validationPatterns: chatItemOption.validationPatterns,
               placeholder: chatItemOption.placeholder,
               ...(this.getValidationHandler(chatItemOption))
@@ -127,6 +129,7 @@ export class ChatItemFormItemsWrapper {
               description,
               fireModifierAndEnterKeyPress,
               value,
+              mandatory: chatItemOption.mandatory,
               validationPatterns: chatItemOption.validationPatterns,
               type: 'number',
               placeholder: chatItemOption.placeholder,
@@ -140,6 +143,7 @@ export class ChatItemFormItemsWrapper {
               description,
               fireModifierAndEnterKeyPress,
               value,
+              mandatory: chatItemOption.mandatory,
               validationPatterns: chatItemOption.validationPatterns,
               type: 'email',
               placeholder: chatItemOption.placeholder,
@@ -191,7 +195,7 @@ export class ChatItemFormItemsWrapper {
       validationState = isMandatoryItemValid(value ?? '');
     }
     if (((chatItemOption.type === 'textarea' || chatItemOption.type === 'textinput') && chatItemOption.validationPatterns != null)) {
-      validationState = validationState && isTextualFormItemValid(value ?? '', chatItemOption.validationPatterns ?? { patterns: [] }).isValid;
+      validationState = validationState && isTextualFormItemValid(value ?? '', chatItemOption.validationPatterns ?? { patterns: [] }, chatItemOption.mandatory).isValid;
     }
 
     return validationState;

--- a/src/components/form-items/text-area.ts
+++ b/src/components/form-items/text-area.ts
@@ -5,7 +5,7 @@
 
 import { Config } from '../../helper/config';
 import { DomBuilder, ExtendedHTMLElement } from '../../helper/dom';
-import { isTextualFormItemValid } from '../../helper/validator';
+import { checkTextElementValidation } from '../../helper/validator';
 import { ValidationPattern } from '../../static';
 import '../../styles/components/_form-input.scss';
 
@@ -14,6 +14,7 @@ export interface TextAreaProps {
   attributes?: Record<string, string>;
   label?: HTMLElement | ExtendedHTMLElement | string;
   description?: ExtendedHTMLElement;
+  mandatory?: boolean;
   fireModifierAndEnterKeyPress?: () => void;
   placeholder?: string;
   validationPatterns?: {
@@ -112,17 +113,7 @@ export class TextAreaInternal extends TextAreaAbstract {
     }
   };
 
-  checkValidation = (): void => {
-    const validationStatus = isTextualFormItemValid(this.inputElement.value, this.props.validationPatterns ?? { patterns: [] });
-    if (this.readyToValidate && validationStatus.validationErrors.length > 0) {
-      this.inputElement.addClass('validation-error');
-      this.validationErrorBlock.update({ children: validationStatus.validationErrors.map(message => DomBuilder.getInstance().build({ type: 'span', children: [ message ] })) });
-    } else {
-      this.readyToValidate = false;
-      this.validationErrorBlock.clear();
-      this.inputElement.removeClass('validation-error');
-    }
-  };
+  checkValidation = (): void => checkTextElementValidation(this.inputElement, this.props.validationPatterns, this.validationErrorBlock, this.readyToValidate, this.props.mandatory);
 }
 
 export class TextArea extends TextAreaAbstract {

--- a/src/components/form-items/text-input.ts
+++ b/src/components/form-items/text-input.ts
@@ -5,7 +5,7 @@
 
 import { Config } from '../../helper/config';
 import { DomBuilder, ExtendedHTMLElement } from '../../helper/dom';
-import { isTextualFormItemValid } from '../../helper/validator';
+import { checkTextElementValidation } from '../../helper/validator';
 import { ValidationPattern } from '../../static';
 import '../../styles/components/_form-input.scss';
 
@@ -14,6 +14,7 @@ export interface TextInputProps {
   attributes?: Record<string, string>;
   label?: HTMLElement | ExtendedHTMLElement | string;
   description?: ExtendedHTMLElement;
+  mandatory?: boolean;
   fireModifierAndEnterKeyPress?: () => void;
   placeholder?: string;
   type?: 'text' | 'number' | 'email';
@@ -116,17 +117,7 @@ export class TextInputInternal extends TextInputAbstract {
     }
   };
 
-  checkValidation = (): void => {
-    const validationStatus = isTextualFormItemValid(this.inputElement.value, this.props.validationPatterns ?? { patterns: [] });
-    if (this.readyToValidate && validationStatus.validationErrors.length > 0) {
-      this.inputElement.addClass('validation-error');
-      this.validationErrorBlock.update({ children: validationStatus.validationErrors.map(message => DomBuilder.getInstance().build({ type: 'span', children: [ message ] })) });
-    } else {
-      this.readyToValidate = false;
-      this.validationErrorBlock.clear();
-      this.inputElement.removeClass('validation-error');
-    }
-  };
+  checkValidation = (): void => checkTextElementValidation(this.inputElement, this.props.validationPatterns, this.validationErrorBlock, this.readyToValidate, this.props.mandatory);
 }
 
 export class TextInput extends TextInputAbstract {

--- a/src/helper/validator.ts
+++ b/src/helper/validator.ts
@@ -28,14 +28,13 @@ export const isTextualFormItemValid = (value: string, validationPatterns: {
       return prevValidation || isCurrentPatternValid;
     }, validationPatterns.operator === 'and');
   }
+  // Don't invalidate if the field is empty and non mandatory
+  isValid = isValid || ((value === undefined || value.trim() === '') && (mandatory !== true));
   if (isValid) {
     validationErrors = [];
   } else if (validationErrors.length === 0 && validationPatterns.genericValidationErrorMessage != null) {
     validationErrors.push(validationPatterns.genericValidationErrorMessage);
   }
-
-  // Don't invalidate if the field is empty and non mandatory
-  isValid = isValid || ((value === undefined || value.trim() === '') && (mandatory !== true));
   return { isValid, validationErrors };
 };
 
@@ -45,10 +44,10 @@ export const checkTextElementValidation = (inputElement: ExtendedHTMLElement, va
   operator?: 'and' | 'or';
   patterns: ValidationPattern[];
 } | undefined, validationErrorBlock: ExtendedHTMLElement, readyToValidate: boolean, mandatory?: boolean): void => {
-  const validationStatus = isTextualFormItemValid(inputElement.value, validationPatterns ?? { patterns: [] }, mandatory);
-  if (readyToValidate && validationStatus.validationErrors.length > 0 && !validationStatus.isValid) {
+  const { isValid, validationErrors } = isTextualFormItemValid(inputElement.value, validationPatterns ?? { patterns: [] }, mandatory);
+  if (readyToValidate && validationErrors.length > 0 && !isValid) {
     inputElement.addClass('validation-error');
-    validationErrorBlock.update({ children: validationStatus.validationErrors.map(message => DomBuilder.getInstance().build({ type: 'span', children: [ message ] })) });
+    validationErrorBlock.update({ children: validationErrors.map(message => DomBuilder.getInstance().build({ type: 'span', children: [ message ] })) });
   } else {
     readyToValidate = false;
     validationErrorBlock.clear();


### PR DESCRIPTION
## Problem
The newly introduced form input validators should only apply if the field is non-empty or mandatory.

## Solution
Updated the text input validator function to take into account these parameters.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
