### PR TITLE
Jurredr/context tooltip bug

### DIFF
--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -885,7 +885,7 @@ interface ChatItemContent {
     rootFolderTitle?: string;
     filePaths?: string[];
     deletedFiles?: string[];
-    collapsedByDefault?: boolean;
+    collapsed?: boolean;
     hideFileCount?: boolean;
     actions?: Record<string, FileNodeAction[]>;
     details?: Record<string, TreeNodeDetails>;
@@ -1772,7 +1772,7 @@ mynahUI.addChatItem(tabId, {
     deletedFiles: ['src/devfile.yaml'],
     // fileTreeTitle: "Custom file tree card title";
     // rootFolderTitle: "Custom root folder title";
-    // collapsedByDefault: true // Collapse the root folder by default
+    // collapsed: true // Collapse the root folder by default
     // hideFileCount: true // Hide the file counter next to folders
     actions: {
       'src/App.tsx': [

--- a/src/components/chat-item/chat-item-card.ts
+++ b/src/components/chat-item/chat-item-card.ts
@@ -346,7 +346,7 @@ export class ChatItemCard {
         cardTitle: this.props.chatItem.fileList.fileTreeTitle,
         rootTitle: this.props.chatItem.fileList.rootFolderTitle,
         hideFileCount: this.props.chatItem.fileList.hideFileCount ?? false,
-        collapsedByDefault: this.props.chatItem.fileList.collapsedByDefault ?? false,
+        collapsed: this.props.chatItem.fileList.collapsed ?? false,
         files: filePaths,
         deletedFiles,
         actions,

--- a/src/components/chat-item/chat-item-tree-view-wrapper.ts
+++ b/src/components/chat-item/chat-item-tree-view-wrapper.ts
@@ -24,7 +24,7 @@ export interface ChatItemTreeViewWrapperProps {
   actions?: Record<string, FileNodeAction[]>;
   details?: Record<string, TreeNodeDetails>;
   hideFileCount?: boolean;
-  collapsedByDefault?: boolean;
+  collapsed?: boolean;
   referenceSuggestionLabel: string;
   references: ReferenceTrackerInformation[];
 }
@@ -55,7 +55,7 @@ export class ChatItemTreeViewWrapper {
         tabId: props.tabId,
         node: fileListToTree(props.files, props.deletedFiles, props.actions, props.details, props.rootTitle),
         hideFileCount: props.hideFileCount,
-        collapsedByDefault: props.collapsedByDefault
+        collapsed: props.collapsed
       }).render;
 
     this.render = DomBuilder.getInstance().build({

--- a/src/components/chat-item/chat-item-tree-view.ts
+++ b/src/components/chat-item/chat-item-tree-view.ts
@@ -13,7 +13,7 @@ export interface ChatItemTreeViewProps {
   tabId: string;
   messageId: string;
   hideFileCount?: boolean;
-  collapsedByDefault?: boolean;
+  collapsed?: boolean;
 }
 
 export class ChatItemTreeView {
@@ -30,7 +30,7 @@ export class ChatItemTreeView {
     this.tabId = props.tabId;
     this.messageId = props.messageId;
     this.hideFileCount = props.hideFileCount ?? false;
-    this.isOpen = !(props.collapsedByDefault ?? false);
+    this.isOpen = !(props.collapsed ?? false);
     this.depth = props.depth ?? 0;
     this.render = DomBuilder.getInstance().build({
       type: 'div',

--- a/src/components/chat-item/prompt-input/prompt-text-input.ts
+++ b/src/components/chat-item/prompt-input/prompt-text-input.ts
@@ -67,6 +67,7 @@ export class PromptTextInput {
           } else {
             this.keydownSupport = false;
           }
+          this.hideContextTooltip();
         },
         input: (e: KeyboardEvent) => {
           if (this.props.onInput !== undefined) {
@@ -288,7 +289,9 @@ export class PromptTextInput {
   };
 
   private readonly hideContextTooltip = (): void => {
-    clearTimeout(this.contextTooltipTimeout);
+    if (this.contextTooltipTimeout !== null) {
+      clearTimeout(this.contextTooltipTimeout);
+    }
     if (this.contextTooltip !== null) {
       this.contextTooltip.close();
       this.contextTooltip = null;

--- a/src/static.ts
+++ b/src/static.ts
@@ -271,7 +271,7 @@ export interface ChatItemContent {
     rootFolderTitle?: string;
     filePaths?: string[];
     deletedFiles?: string[];
-    collapsedByDefault?: boolean;
+    collapsed?: boolean;
     hideFileCount?: boolean;
     actions?: Record<string, FileNodeAction[]>;
     details?: Record<string, TreeNodeDetails>;


### PR DESCRIPTION
## Changes
- Fixed a bug with the context selector tooltip where it would stay open, even after the context item is removed from prompt input.
- Renamed 'collapsedByDefault' to 'collapsed' on the file tree component for better naming

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
