### PR TITLE
Dogusata beta/fix card header refresh

### DIFF
--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -528,7 +528,7 @@ This event will be fired whenever a user selects an item from the context (`@`) 
 ```typescript
 ...
 onContextSelected(contextItem: QuickActionCommand) {
-  if (contextItem.command === 'add_prompt') {
+  if (contextItem.command === 'Add Prompt') {
     Log('Custom context action triggered for adding a prompt!')
     return false;
   }

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -302,9 +302,8 @@ export const mynahUIDefaults: Partial<MynahUITabStoreTab> = {
                     description: 'Expert on Javascript and typescript'
                   },
                   {
-                    command: 'add_prompt',
+                    command: 'Add Prompt',
                     icon: MynahIcons.PLUS,
-                    description: 'Add a new prompt'
                   }
                 ]
               }

--- a/example/src/connector.ts
+++ b/example/src/connector.ts
@@ -1,7 +1,7 @@
 import { ChatItem } from '@aws/mynah-ui';
 import { Log } from './logger';
 const STREAM_DELAY = 350;
-export const INITIAL_STREAM_DELAY = 1750;
+export const INITIAL_STREAM_DELAY = 150;
 
 export class Connector {
   requestGenerativeAIAnswer = async (

--- a/example/src/connector.ts
+++ b/example/src/connector.ts
@@ -1,7 +1,7 @@
 import { ChatItem } from '@aws/mynah-ui';
 import { Log } from './logger';
 const STREAM_DELAY = 350;
-export const INITIAL_STREAM_DELAY = 150;
+export const INITIAL_STREAM_DELAY = 1750;
 
 export class Connector {
   requestGenerativeAIAnswer = async (

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -230,7 +230,7 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
       Log(`New tab added: <b>${tabId}</b>`);
     },
     onContextSelected(contextItem) {
-      if (contextItem.command === 'add_prompt') {
+      if (contextItem.command === 'Add Prompt') {
         Log('Custom context action triggered for adding a prompt!')
         return false;
       }

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -744,7 +744,37 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
     });
     connector
       .requestGenerativeAIAnswer(
-        optionalParts ?? exampleStreamParts,
+        optionalParts ?? [
+          {
+            ...exampleStreamParts[0],
+            header: {
+              fileList: {
+                collapsed: true,
+                hideFileCount: true,
+                flatList: true,
+                rootFolderTitle: 'Context',
+                folderIcon: null,
+                fileTreeTitle: '',
+                filePaths: ['./src/index.ts', './main','js_expert'],
+                details: {
+                  './src/index.ts': {
+                    icon: MynahIcons.FILE,
+                    description: `**index.ts** under **src** folder is
+used as a context to generate this message.`
+                  },
+                  './main': {
+                    icon: MynahIcons.FOLDER,
+                  },
+                  'js_expert': {
+                    icon: MynahIcons.CHAT,
+                  }
+                }
+              }
+            }
+          },
+          {
+            header: undefined,
+          }, ...exampleStreamParts],
         (chatItem: Partial<ChatItem>, percentage: number) => {
           if (streamingMessageId != null) {
             mynahUI.updateChatAnswerWithMessageId(tabId, streamingMessageId, chatItem);
@@ -763,23 +793,7 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
           return true;
         },
         () => {
-          const cardDetails = mynahUI.endMessageStream(tabId, messageId, {
-            footer: {
-              fileList: {
-                rootFolderTitle: undefined,
-                fileTreeTitle: '',
-                filePaths: ['./src/index.ts'],
-                details: {
-                  './src/index.ts': {
-                    icon: MynahIcons.FILE,
-                    clickable: false,
-                    description: `Files used for this response: **index.ts**
-Use \`@\` to mention a file, folder, or method.`
-                  }
-                }
-              }
-            }
-          }) as Record<string, any>;
+          const cardDetails = mynahUI.endMessageStream(tabId, messageId, {}) as Record<string, any>;
 
           mynahUI.updateStore(tabId, {
             loadingChat: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.23.0-beta.9",
+    "version": "4.23.0-beta.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.23.0-beta.9",
+            "version": "4.23.0-beta.10",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.23.0-beta.10",
+    "version": "4.23.0-beta.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.23.0-beta.10",
+            "version": "4.23.0-beta.11",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.23.0-beta.10",
+    "version": "4.23.0-beta.11",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.23.0-beta.9",
+    "version": "4.23.0-beta.10",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/components/chat-item/chat-item-card.ts
+++ b/src/components/chat-item/chat-item-card.ts
@@ -200,36 +200,37 @@ export class ChatItemCard {
       this.initialSpinner?.[0]?.remove();
     }
 
-    /**
-     * Clear header block
-     */
-    if (this.cardHeader != null) {
-      this.cardHeader.remove();
-      this.cardHeader = null;
-    }
-    if (this.props.chatItem.header != null) {
-      this.cardHeader = this.getCardHeader();
-      this.card?.render.insertChild('beforeend', this.cardHeader);
-
-      /**
-       * Generate header if available
-       */
-      if (this.header != null) {
-        this.header.render.remove();
-        this.header = null;
+    // If no data is provided for the header
+    // skip removing and checking it
+    if (this.props.chatItem.header !== undefined) {
+      if (this.cardHeader != null) {
+        this.cardHeader.remove();
+        this.cardHeader = null;
       }
       if (this.props.chatItem.header != null) {
-        this.header = new ChatItemCard({
-          tabId: this.props.tabId,
-          small: true,
-          inline: true,
-          chatItem: {
-            ...this.props.chatItem.header,
-            type: ChatItemType.ANSWER,
-            messageId: this.props.chatItem.messageId
-          }
-        });
-        this.cardHeader.insertChild('beforeend', this.header.render);
+        this.cardHeader = this.getCardHeader();
+        this.card?.render.insertChild('beforeend', this.cardHeader);
+
+        /**
+         * Generate header if available
+         */
+        if (this.header != null) {
+          this.header.render.remove();
+          this.header = null;
+        }
+        if (this.props.chatItem.header != null) {
+          this.header = new ChatItemCard({
+            tabId: this.props.tabId,
+            small: true,
+            inline: true,
+            chatItem: {
+              ...this.props.chatItem.header,
+              type: ChatItemType.ANSWER,
+              messageId: this.props.chatItem.messageId
+            }
+          });
+          this.cardHeader.insertChild('beforeend', this.header.render);
+        }
       }
     }
 

--- a/src/components/chat-item/chat-item-card.ts
+++ b/src/components/chat-item/chat-item-card.ts
@@ -346,6 +346,7 @@ export class ChatItemCard {
         messageId: this.props.chatItem.messageId ?? '',
         cardTitle: this.props.chatItem.fileList.fileTreeTitle,
         rootTitle: this.props.chatItem.fileList.rootFolderTitle,
+        folderIcon: this.props.chatItem.fileList.folderIcon,
         hideFileCount: this.props.chatItem.fileList.hideFileCount ?? false,
         collapsed: this.props.chatItem.fileList.collapsed ?? false,
         files: filePaths,

--- a/src/components/chat-item/chat-item-tree-view-wrapper.ts
+++ b/src/components/chat-item/chat-item-tree-view-wrapper.ts
@@ -8,7 +8,7 @@ import testIds from '../../helper/test-ids';
 import { DomBuilder, ExtendedHTMLElement } from '../../helper/dom';
 import { fileListToTree } from '../../helper/file-tree';
 import { FileNodeAction, ReferenceTrackerInformation, TreeNodeDetails } from '../../static';
-import { MynahIcons } from '../icon';
+import { MynahIcons, MynahIconsType } from '../icon';
 import { ChatItemTreeFile } from './chat-item-tree-file';
 import { ChatItemTreeView } from './chat-item-tree-view';
 import { ChatItemTreeViewLicense } from './chat-item-tree-view-license';
@@ -22,6 +22,7 @@ export interface ChatItemTreeViewWrapperProps {
   rootTitle?: string;
   deletedFiles: string[];
   flatList?: boolean;
+  folderIcon?: MynahIcons | MynahIconsType | null;
   actions?: Record<string, FileNodeAction[]>;
   details?: Record<string, TreeNodeDetails>;
   hideFileCount?: boolean;
@@ -53,6 +54,7 @@ export class ChatItemTreeViewWrapper {
       }).render
       : new ChatItemTreeView({
         messageId: props.messageId,
+        folderIcon: props.folderIcon,
         tabId: props.tabId,
         node: fileListToTree(props.files, props.deletedFiles, props.actions, props.details, props.rootTitle),
         hideFileCount: props.hideFileCount,

--- a/src/components/chat-item/chat-item-tree-view.ts
+++ b/src/components/chat-item/chat-item-tree-view.ts
@@ -4,7 +4,7 @@ import { cancelEvent } from '../../helper/events';
 import { TreeNode } from '../../helper/file-tree';
 import testIds from '../../helper/test-ids';
 import { Button } from '../button';
-import { Icon, MynahIcons } from '../icon';
+import { Icon, MynahIcons, MynahIconsType } from '../icon';
 import { ChatItemTreeFile } from './chat-item-tree-file';
 
 export interface ChatItemTreeViewProps {
@@ -14,10 +14,12 @@ export interface ChatItemTreeViewProps {
   messageId: string;
   hideFileCount?: boolean;
   collapsed?: boolean;
+  folderIcon?: MynahIcons | MynahIconsType | null;
 }
 
 export class ChatItemTreeView {
   private readonly node: TreeNode;
+  private readonly folderIcon: MynahIcons | MynahIconsType | null;
   private isOpen: boolean;
   private readonly depth: number;
   private readonly tabId: string;
@@ -27,6 +29,7 @@ export class ChatItemTreeView {
 
   constructor (props: ChatItemTreeViewProps) {
     this.node = props.node;
+    this.folderIcon = props.folderIcon === null ? null : props.folderIcon ?? MynahIcons.FOLDER;
     this.tabId = props.tabId;
     this.messageId = props.messageId;
     this.hideFileCount = props.hideFileCount ?? false;
@@ -61,7 +64,14 @@ export class ChatItemTreeView {
         DomBuilder.getInstance().build({
           type: 'div',
           classNames: [ 'mynah-chat-item-folder-child' ],
-          children: [ new ChatItemTreeView({ node: childNode, depth: this.depth + 1, tabId: this.tabId, hideFileCount: this.hideFileCount, messageId: this.messageId }).render ],
+          children: [ new ChatItemTreeView({
+            folderIcon: this.folderIcon,
+            node: childNode,
+            depth: this.depth + 1,
+            tabId: this.tabId,
+            hideFileCount: this.hideFileCount,
+            messageId: this.messageId
+          }).render ],
         })
       )
       : [];
@@ -79,7 +89,7 @@ export class ChatItemTreeView {
         type: 'div',
         classNames: [ 'mynah-chat-item-tree-view-button-title' ],
         children: [
-          new Icon({ icon: MynahIcons.FOLDER }).render,
+          ...(this.folderIcon !== null ? [ new Icon({ icon: this.folderIcon }).render ] : []),
           {
             type: 'span',
             children: [ this.node.name ]

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -413,7 +413,7 @@ export class ChatPromptInput {
                   } else {
                     this.searchTerm = this.searchTerm.slice(0, -1);
                   }
-                } else {
+                } else if (e.key.length === 1) {
                   this.searchTerm += e.key.toLowerCase();
                 }
                 this.filteredQuickPickItemGroups = filterQuickPickItems([ ...this.quickPickItemGroups ], this.searchTerm);
@@ -483,6 +483,7 @@ export class ChatPromptInput {
       this.quickPickItemsSelectorContainer = new PromptInputQuickPickSelector({
         quickPickGroupList,
         onQuickPickGroupActionClick: (action) => {
+          this.promptTextInput.deleteTextRange(this.quickPickTriggerIndex, this.promptTextInput.getCursorPos());
           MynahUIGlobalEvents.getInstance().dispatch(MynahEventNames.QUICK_COMMAND_GROUP_ACTION_CLICK, {
             tabId: this.props.tabId,
             actionId: action.id

--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -65,6 +65,7 @@ export class ChatPromptInput {
   private readonly userPromptHistory: UserPrompt[] = [];
   private userPromptHistoryIndex: number = -1;
   private lastUnsentUserPrompt: UserPrompt;
+  private readonly markerRemovalRegex = new RegExp(`${MARK_OPEN}|${MARK_CLOSE}`, 'g');
   constructor (props: ChatPromptInputProps) {
     this.props = props;
     this.promptTextInputCommand = new ChatPromptInputCommand({
@@ -508,7 +509,7 @@ export class ChatPromptInput {
     method: 'enter' | 'tab' | 'space' | 'click'): void => {
     const quickActionCommand = {
       ...dirtyQuickActionCommand,
-      command: dirtyQuickActionCommand.command.replace(new RegExp(`${MARK_OPEN}|${MARK_CLOSE}`, 'g'), '')
+      command: dirtyQuickActionCommand.command.replace(this.markerRemovalRegex, '')
     };
 
     this.selectedCommand = quickActionCommand.command;
@@ -531,12 +532,12 @@ export class ChatPromptInput {
   };
 
   private readonly handleContextCommandSelection = (dirtyContextCommand: QuickActionCommand): void => {
-    const contextCommand = {
+    const contextCommand: QuickActionCommand = {
       ...dirtyContextCommand,
-      command: dirtyContextCommand.command.replace(new RegExp(`${MARK_OPEN}|${MARK_CLOSE}`, 'g'), '')
+      command: dirtyContextCommand.command.replace(this.markerRemovalRegex, '')
     };
     // Check if the selected command has children
-    if (contextCommand.children != null && contextCommand.children?.length > 0) {
+    if (contextCommand.children?.[0] != null) {
       this.promptTextInput.deleteTextRange(this.quickPickTriggerIndex + 1, this.promptTextInput.getCursorPos());
       this.quickPickItemGroups = [ ...contextCommand.children ];
       this.quickPick.updateContent([

--- a/src/components/chat-item/prompt-input/prompt-input-quick-pick-item.ts
+++ b/src/components/chat-item/prompt-input/prompt-input-quick-pick-item.ts
@@ -46,7 +46,7 @@ export class PromptInputQuickPickItem {
         {
           type: 'div',
           classNames: [ 'mynah-chat-command-selector-command-name' ],
-          children: [ this.props.quickPickItem.command ]
+          innerHTML: this.props.quickPickItem.command
         },
         ...(this.props.quickPickItem.description !== undefined
           ? [ {

--- a/src/components/chat-item/prompt-input/prompt-input-quick-pick-item.ts
+++ b/src/components/chat-item/prompt-input/prompt-input-quick-pick-item.ts
@@ -32,35 +32,38 @@ export class PromptInputQuickPickItem {
       children: [
         ...(this.props.quickPickItem.icon !== undefined
           ? [
-              new Icon({
-                icon: this.props.quickPickItem.icon
-              }).render
+              {
+                type: 'div',
+                classNames: [ 'mynah-chat-command-selector-icon' ],
+                children: [
+                  new Icon({
+                    icon: this.props.quickPickItem.icon
+                  }).render
+                ]
+              }
             ]
           : []),
         {
           type: 'div',
-          classNames: [ 'mynah-chat-command-selector-command-container' ],
-          children: [
-            {
-              type: 'div',
-              classNames: [ 'mynah-chat-command-selector-command-name' ],
-              children: [ this.props.quickPickItem.command ]
-            },
-            ...(this.props.quickPickItem.description !== undefined
-              ? [ {
-                  type: 'div',
-                  classNames: [ 'mynah-chat-command-selector-command-description' ],
-                  children: [ this.props.quickPickItem.description ]
-                } ]
-              : [])
-          ]
+          classNames: [ 'mynah-chat-command-selector-command-name' ],
+          children: [ this.props.quickPickItem.command ]
         },
+        ...(this.props.quickPickItem.description !== undefined
+          ? [ {
+              type: 'div',
+              classNames: [ 'mynah-chat-command-selector-command-description' ],
+              children: [ this.props.quickPickItem.description ]
+            } ]
+          : []),
         ...((this.props.quickPickItem.children != null) && this.props.quickPickItem.children.length > 0
           ? [
-              new Icon({
-                icon: 'right-open',
-                classNames: [ 'mynah-chat-command-selector-command-arrow-icon' ]
-              }).render
+              {
+                type: 'div',
+                classNames: [ 'mynah-chat-command-selector-command-arrow-icon' ],
+                children: [
+                  new Icon({ icon: 'right-open' }).render
+                ]
+              }
             ]
           : [])
       ]

--- a/src/components/chat-item/prompt-input/prompt-input-quick-pick-selector.ts
+++ b/src/components/chat-item/prompt-input/prompt-input-quick-pick-selector.ts
@@ -14,7 +14,7 @@ export interface PromptInputQuickPickSelectorProps {
 export class PromptInputQuickPickSelector {
   render: ExtendedHTMLElement;
   private readonly props: PromptInputQuickPickSelectorProps;
-  private activeTargetElementIndex: number = -1;
+  private activeTargetElementIndex: number = 0;
   private allSelectableQuickPickElements: PromptInputQuickPickItem[] = [];
   constructor (props: PromptInputQuickPickSelectorProps) {
     this.props = props;
@@ -27,7 +27,7 @@ export class PromptInputQuickPickSelector {
   }
 
   private readonly getQuickPickGroups = (): ExtendedHTMLElement[] => {
-    return this.props.quickPickGroupList.map((quickPickGroup) => {
+    const groups = this.props.quickPickGroupList.map((quickPickGroup) => {
       return DomBuilder.getInstance().build({
         type: 'div',
         testId: testIds.prompt.quickPicksGroup,
@@ -72,6 +72,8 @@ export class PromptInputQuickPickSelector {
         ]
       });
     });
+    this.allSelectableQuickPickElements[0]?.setFocus(true);
+    return groups;
   };
 
   public readonly changeTarget = (direction: 'up' | 'down'): void => {
@@ -91,9 +93,7 @@ export class PromptInputQuickPickSelector {
         }
       }
 
-      if (this.activeTargetElementIndex !== -1) {
-        this.allSelectableQuickPickElements[this.activeTargetElementIndex].setFocus(false);
-      }
+      this.allSelectableQuickPickElements[this.activeTargetElementIndex].setFocus(false);
       this.activeTargetElementIndex = nextElementIndex;
       this.allSelectableQuickPickElements[this.activeTargetElementIndex].setFocus(true);
     }
@@ -107,7 +107,7 @@ export class PromptInputQuickPickSelector {
   };
 
   public readonly updateList = (quickPickGroupList: QuickActionCommandGroup[]): void => {
-    this.activeTargetElementIndex = -1;
+    this.activeTargetElementIndex = 0;
     this.allSelectableQuickPickElements = [];
     this.props.quickPickGroupList = quickPickGroupList;
     this.render.update({

--- a/src/components/chat-item/prompt-input/prompt-text-input.ts
+++ b/src/components/chat-item/prompt-input/prompt-text-input.ts
@@ -91,30 +91,31 @@ export class PromptTextInput {
             this.props.onBlur();
           }
         },
-        paste: (e: ClipboardEvent) => {
+        paste: (e: ClipboardEvent): void => {
           // Prevent the default paste behavior
           e.preventDefault();
 
           // Get plain text from clipboard
-          const text = e.clipboardData?.getData('text/plain') ?? '';
+          const text = e.clipboardData?.getData('text/plain');
+          if (text != null) {
+            // Insert text at cursor position
+            const selection = window.getSelection();
+            if ((selection?.rangeCount) != null) {
+              const range = selection.getRangeAt(0);
+              range.deleteContents();
+              range.insertNode(document.createTextNode(text));
 
-          // Insert text at cursor position
-          const selection = window.getSelection();
-          if ((selection?.rangeCount) != null) {
-            const range = selection.getRangeAt(0);
-            range.deleteContents();
-            range.insertNode(document.createTextNode(text));
+              // Move cursor to end of inserted text
+              range.collapse(false);
+              selection.removeAllRanges();
+              selection.addRange(range);
+            }
 
-            // Move cursor to end of inserted text
-            range.collapse(false);
-            selection.removeAllRanges();
-            selection.addRange(range);
-          }
-
-          // Check if input is empty and trigger input event
-          this.checkIsEmpty();
-          if (this.props.onInput != null) {
-            this.props.onInput(new KeyboardEvent('input'));
+            // Check if input is empty and trigger input event
+            this.checkIsEmpty();
+            if (this.props.onInput != null) {
+              this.props.onInput(new KeyboardEvent('input'));
+            }
           }
         },
       },

--- a/src/helper/quick-pick-data-handler.ts
+++ b/src/helper/quick-pick-data-handler.ts
@@ -1,31 +1,141 @@
-import { QuickActionCommandGroup } from '../static';
+import escapeHTML from 'escape-html';
+import { QuickActionCommand, QuickActionCommandGroup } from '../static';
 
 export const filterQuickPickItems = (commands: QuickActionCommandGroup[], searchTerm: string): QuickActionCommandGroup[] => {
   if (searchTerm.trim() === '') {
     return commands;
   }
 
-  const filteredQuickPickItemGroups: QuickActionCommandGroup[] = [];
-  commands.forEach((quickPickGroup: QuickActionCommandGroup) => {
-    const newQuickPickCommandGroup = { ...quickPickGroup };
-    try {
-      const promptRegex = new RegExp(searchTerm ?? '', 'gi');
-      // Filter self
-      newQuickPickCommandGroup.commands = newQuickPickCommandGroup.commands.filter(command => command.command.match(promptRegex) != null);
+  const matchedCommands: QuickActionCommand[] = [];
 
-      if (newQuickPickCommandGroup.commands.length > 0) {
-        filteredQuickPickItemGroups.push(newQuickPickCommandGroup);
-      }
-
-      // Filter children
-      quickPickGroup.commands.forEach(command => {
-        if (command.children != null && command.children.length > 0) {
-          filteredQuickPickItemGroups.push(...filterQuickPickItems([ ...command.children ], searchTerm));
-        }
+  const findMatches = (cmd: QuickActionCommand): void => {
+    const score = calculateItemScore(cmd.command, searchTerm);
+    if (score > 0) {
+      matchedCommands.push({
+        ...cmd,
+        // Update command with highlighted text
+        // It is being reverted when user makes the selection
+        command: highlightMatch(escapeHTML(cmd.command), searchTerm)
       });
-    } catch (e) {
-      // In case the prompt is an incomplete regex
     }
+
+    // Search for children
+    cmd.children?.forEach(childGroup => {
+      childGroup.commands.forEach(childCmd => {
+        findMatches(childCmd);
+      });
+    });
+  };
+
+  // Filter all commands
+  commands.forEach(group => {
+    group.commands.forEach(cmd => {
+      findMatches(cmd);
+    });
   });
-  return filteredQuickPickItemGroups;
+
+  if (matchedCommands.length > 0) {
+    return [ {
+      commands: matchedCommands
+    } ];
+  }
+
+  return [];
+};
+
+export const MARK_OPEN = '<mark>';
+export const MARK_CLOSE = '</mark>';
+
+const highlightMatch = (text: string, searchTerm: string): string => {
+  const textToCompare = text.toLowerCase();
+  const searchTermToCompare = searchTerm.toLowerCase();
+
+  // Exact
+  if (textToCompare === searchTermToCompare) {
+    return `${MARK_OPEN}${text}${MARK_CLOSE}`;
+  }
+
+  // Prefix
+  if (textToCompare.startsWith(searchTermToCompare)) {
+    const matchLength = searchTerm.length;
+    const matchedPart = text.slice(0, matchLength);
+    const restPart = text.slice(matchLength);
+    return `${MARK_OPEN}${matchedPart}${MARK_CLOSE}${restPart}`;
+  }
+
+  // Contains
+  const startIndex = textToCompare.indexOf(searchTermToCompare);
+  if (startIndex !== -1) {
+    const before = text.slice(0, startIndex);
+    const match = text.slice(startIndex, startIndex + searchTerm.length);
+    const after = text.slice(startIndex + searchTerm.length);
+    return `${before}${MARK_OPEN}${match}${MARK_CLOSE}${after}`;
+  }
+
+  // Words
+  const words = text.split(' ');
+  for (let i = 0; i < words.length; i++) {
+    const word = words[i].toLowerCase();
+    if (word.includes(searchTermToCompare)) {
+      const startIdx = word.indexOf(searchTermToCompare);
+      const originalWord = words[i];
+      words[i] =
+              originalWord.slice(0, startIdx) +
+              `${MARK_OPEN}${originalWord.slice(startIdx, startIdx + searchTerm.length)}${MARK_CLOSE}` +
+              originalWord.slice(startIdx + searchTerm.length);
+      return words.join(' ');
+    }
+  }
+
+  // Partial
+  let result = '';
+  let lastIndex = 0;
+  let termIndex = 0;
+
+  for (let i = 0; i < text.length && termIndex < searchTerm.length; i++) {
+    if (text[i].toLowerCase() === searchTerm[termIndex].toLowerCase()) {
+      result += text.slice(lastIndex, i);
+      result += `${MARK_OPEN}${text[i]}${MARK_CLOSE}`;
+      lastIndex = i + 1;
+      termIndex++;
+    }
+  }
+  result += text.slice(lastIndex);
+
+  return termIndex === searchTerm.length ? result : text;
+};
+
+const calculateItemScore = (text: string, searchTerm: string): number => {
+  const normalizedText = text.toLowerCase();
+  const normalizedTerm = searchTerm.toLowerCase();
+
+  const isExactMatch = normalizedText === normalizedTerm;
+  const isPrefixMatch = normalizedText.startsWith(normalizedTerm);
+  const isWordStartMatch = normalizedText.split(' ').some(word => word.startsWith(normalizedTerm));
+  const isContainsMatch = normalizedText.includes(normalizedTerm);
+
+  if (isExactMatch) return 100;
+  if (isPrefixMatch) return 80;
+  if (isWordStartMatch) return 60;
+  if (isContainsMatch) return 40;
+
+  return calculateScore(normalizedText, normalizedTerm);
+};
+
+const calculateScore = (text: string, term: string): number => {
+  let score = 0;
+  let termIndex = 0;
+  let consecutiveMatches = 0;
+
+  for (let i = 0; i < text.length && termIndex < term.length; i++) {
+    if (text[i] === term[termIndex]) {
+      score += 10 + consecutiveMatches;
+      consecutiveMatches++;
+      termIndex++;
+    } else {
+      consecutiveMatches = 0;
+    }
+  }
+
+  return termIndex === term.length ? score : 0;
 };

--- a/src/static.ts
+++ b/src/static.ts
@@ -272,6 +272,7 @@ export interface ChatItemContent {
     filePaths?: string[];
     deletedFiles?: string[];
     flatList?: boolean;
+    folderIcon?: MynahIcons | MynahIconsType | null;
     collapsed?: boolean;
     hideFileCount?: boolean;
     actions?: Record<string, FileNodeAction[]>;

--- a/src/styles/components/chat/_chat-command-selector.scss
+++ b/src/styles/components/chat/_chat-command-selector.scss
@@ -50,7 +50,11 @@
         }
 
         > .mynah-chat-command-selector-command {
-            display: flex;
+            display: grid;
+            grid-template-columns: auto 1fr auto;
+            grid-template-rows: auto auto;
+            row-gap: var(--mynah-sizing-1);
+            column-gap: var(--mynah-sizing-2);
             position: relative;
             box-sizing: border-box;
             width: 100%;
@@ -59,11 +63,10 @@
             justify-content: flex-start;
             overflow: hidden;
             cursor: pointer;
-            padding: var(--mynah-sizing-2) var(--mynah-sizing-3);
+            padding: var(--mynah-sizing-2);
             color: var(--mynah-color-text-default);
             border-radius: var(--mynah-input-radius);
             transition: var(--mynah-short-transition-rev);
-            gap: var(--mynah-sizing-3);
 
             &[disabled='true'] {
                 &::before {
@@ -87,54 +90,39 @@
                     }
                 }
             }
-            > .mynah-ui-icon {
-                margin-top: var(--mynah-sizing-half);
-                font-size: var(--mynah-font-size-large);
+            > .mynah-chat-command-selector-icon {
+                align-self: center;
+                grid-row: 1;
+                grid-column: 1;
+                > .mynah-ui-icon {
+                    font-size: var(--mynah-font-size-large);
+                }
                 color: var(--mynah-color-text-default);
             }
 
-            &:not(:hover):not(.target-command) > .mynah-chat-command-selector-command-arrow-icon {
-                display: none;
+            > .mynah-chat-command-selector-command-name {
+                align-self: center;
+                grid-row: 1;
+                grid-column: 2;
+                font-family: var(--mynah-font-family);
+                font-weight: bold;
             }
 
-            > .mynah-chat-command-selector-command-container {
-                flex: 1;
-                display: flex;
-                position: relative;
-                box-sizing: border-box;
-                flex-flow: column nowrap;
-                align-items: flex-start;
-                justify-content: flex-start;
-                overflow: hidden;
-                gap: var(--mynah-sizing-1);
-
-                > .mynah-chat-command-selector-command-name {
-                    font-family: var(--mynah-font-family);
-                    font-weight: bold;
-                    flex: 0 1 0%;
-                }
-                > .mynah-chat-command-selector-command-description {
-                    color: var(--mynah-color-text-weak);
-                    flex: 1 0 100%;
-                }
+            > .mynah-chat-command-selector-command-arrow-icon {
+                grid-row: 1 / -1;
+                grid-column: 3;
+                align-self: center;
             }
-        }
-    }
 
-    &:not(.has-target-item) {
-        > .mynah-chat-command-selector-group:first-child {
-            > .mynah-chat-command-selector-command:first-of-type {
-                &:before {
-                    content: '';
-                    z-index: -1;
-                    border: calc(2 * var(--mynah-border-width)) solid var(--mynah-color-button);
-                    box-sizing: border-box;
-                    position: absolute;
-                    top: 0;
-                    left: 0;
-                    width: 100%;
-                    height: 100%;
-                    border-radius: inherit;
+            > .mynah-chat-command-selector-command-description {
+                grid-row: 2;
+                grid-column: 2;
+                color: var(--mynah-color-text-weak);
+            }
+
+            &:not(:hover):not(.target-command) {
+                > .mynah-chat-command-selector-command-arrow-icon {
+                    opacity: 0;
                 }
             }
         }

--- a/src/styles/components/chat/_chat-command-selector.scss
+++ b/src/styles/components/chat/_chat-command-selector.scss
@@ -106,6 +106,11 @@
                 grid-column: 2;
                 font-family: var(--mynah-font-family);
                 font-weight: bold;
+                > mark {
+                    position: relative;
+                    color: initial !important;
+                    overflow: hidden;
+                }
             }
 
             > .mynah-chat-command-selector-command-arrow-icon {

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -97,7 +97,7 @@
                     overflow-x: hidden;
                     display: block;
                     box-sizing: border-box;
-                    min-height: calc(var(--mynah-line-height) * 5 / 2);
+                    min-height: calc(var(--mynah-line-height) * 3);
 
                     &[disabled] {
                         pointer-events: none;

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -97,7 +97,7 @@
                     overflow-x: hidden;
                     display: block;
                     box-sizing: border-box;
-                    min-height: var(--mynah-line-height);
+                    min-height: calc(var(--mynah-line-height) * 5 / 2);
 
                     &[disabled] {
                         pointer-events: none;
@@ -115,8 +115,9 @@
                             font-size: inherit;
                             color: var(--mynah-color-text-weak);
                             max-width: 100%;
-                            white-space: nowrap;
                             overflow: hidden;
+                            white-space: over;
+                            box-sizing: border-box;
                         }
                     }
 
@@ -377,5 +378,15 @@
         margin-bottom: 0;
         max-width: 100%;
         box-sizing: border-box;
+    }
+}
+
+@media only screen and (max-height: 450px) {
+    > .mynah-chat-prompt-wrapper
+        > .mynah-chat-prompt
+        > .mynah-chat-prompt-input-wrapper
+        > .mynah-chat-prompt-input-inner-wrapper
+        > .mynah-chat-prompt-input {
+        min-height: var(--mynah-line-height);
     }
 }

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -116,7 +116,7 @@
                             color: var(--mynah-color-text-weak);
                             max-width: 100%;
                             overflow: hidden;
-                            white-space: over;
+                            overflow-wrap: break-word;
                             box-sizing: border-box;
                         }
                     }
@@ -388,5 +388,8 @@
         > .mynah-chat-prompt-input-inner-wrapper
         > .mynah-chat-prompt-input {
         min-height: var(--mynah-line-height);
+        &.empty::before {
+            white-space: nowrap;
+        }
     }
 }


### PR DESCRIPTION
## Problem
- It is not possible to use the shift key during filtering the items when the context selector panel is open to add an underscore (`_`) into the search term. It closes the context selector panel when shift is pressed combined with any key
- When the action button on the right of the context group title clicked, the inserted `@` remains on the screen.
- Filtering in quick pick items does make the filter however it doesn't properly order, items contain the search term at the end of their text can appear at the top of the list. And it also shows some items doesn't match the term at all.
- Sometimes the context selection panel gets stuck and doesn't reflect to any input. It requires `esc` keypress to close it and reopen it back
- When choosing items from the context provider, the first item should be indicated as selected before navigating since if user hits enter the first item is being selected.
- When a rich content copied from outside chat panel is pasted to the prompt input, it keeps the styling inside the prompt input. It should only use the plain text.
- Right arrow on context items with children causes the description text to jump to next line and doesn't look vertically aligned in center.
- `header` is re-rendering every time the stream is updated. If the `header` attribute is not sent every time, it shouldn't update the render too
- fileList is insufficient, not able to remove folder icons or use another icon for them.
- Prompt input field doesn't seem like it is possible to insert multiline content. Also, if the placeholder is long, it doesn't show the whole text.

## Solution
- Shift and other modifier keys are not closing the panel. Previously when shift or other modifier keys were pressed, their key definition _(like `"SHIFT"`)_ were being added to search term and it was hiding the panel since there were no items available in the list instead of actually closing the panel.
- When an action button in command/context group title is clicked, it removes the given trigger char (`@` or `/`)
- Filtering in quick pick items is improved with complex match structure and a flat list instead of using groups for easy and better filtering. It can find most relevant items, order them according to their match score and more importantly it highlights the match in the text for clear visibility.
- Context selection panel closes as expected now, solved together with SHIFT or other modifier key presses.
- First item in the quick pick items list is now indicated as it is the target, so users can understand if they hit Enter that item will be selected.
- Rich contents are being converted to plain text before they're being pasted to prompt input.
- Right arrow and other elements on quick pick items are moved to a grid structure to better layout and rendering
- `header` block in ChatCard is not being re-rendered **if it is sent as filled once and than sent as `undefined` (at least once) specifically**. The reason behind that is to avoid re-rendering it. 
- added `folderIcon` option to `fileList` as `MynahIcons | MynahIconsType | null`. If `null` is sent, it will not show icons for folders including the root folder.
- Prompt input min-height is increased to 3 lines height **only** if the window height is **bigger than 450px**.

#### Header (fileList)
<img width="434" alt="image" src="https://github.com/user-attachments/assets/57d11a88-f512-477e-8a45-587a18a774c5" />

#### Filter
<img width="593" alt="image" src="https://github.com/user-attachments/assets/a5379d40-e3e5-432f-b56a-f1a762872a43" />

#### Prompt input height
<img width="349" alt="image" src="https://github.com/user-attachments/assets/7aa9a00b-fcd6-4088-8826-c4b0f91e211a" />

## Tests
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
