### PR TITLE
Dogusata beta/fix context items filter sorting

### DIFF
--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -231,6 +231,11 @@ export const mynahUIDefaults: Partial<MynahUITabStoreTab> = {
                 groupName: 'Files',
                 commands: [
                   {
+                    command: 'monarch.ts',
+                    description: './src/',
+                    icon: MynahIcons.FILE,
+                  },
+                  {
                     command: 'main.ts',
                     description: './src/',
                     icon: MynahIcons.FILE,
@@ -238,6 +243,11 @@ export const mynahUIDefaults: Partial<MynahUITabStoreTab> = {
                   {
                     command: 'button.ts',
                     description: './src/components/',
+                    icon: MynahIcons.FILE,
+                  },
+                  {
+                    command: 'ex-dom.ts',
+                    description: './src/helper/',
                     icon: MynahIcons.FILE,
                   },
                   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.23.0-beta.11",
+    "version": "4.23.0-beta.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.23.0-beta.11",
+            "version": "4.23.0-beta.12",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.23.0-beta.11",
+    "version": "4.23.0-beta.12",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/helper/quick-pick-data-handler.ts
+++ b/src/helper/quick-pick-data-handler.ts
@@ -6,16 +6,19 @@ export const filterQuickPickItems = (commands: QuickActionCommandGroup[], search
     return commands;
   }
 
-  const matchedCommands: QuickActionCommand[] = [];
+  const matchedCommands: Array<{score: number; command: QuickActionCommand}> = [];
 
   const findMatches = (cmd: QuickActionCommand): void => {
     const score = calculateItemScore(cmd.command, searchTerm);
     if (score > 0) {
       matchedCommands.push({
-        ...cmd,
-        // Update command with highlighted text
-        // It is being reverted when user makes the selection
-        command: highlightMatch(escapeHTML(cmd.command), searchTerm)
+        score,
+        command: {
+          ...cmd,
+          // Update command with highlighted text
+          // It is being reverted when user makes the selection
+          command: highlightMatch(escapeHTML(cmd.command), searchTerm)
+        }
       });
     }
 
@@ -36,7 +39,8 @@ export const filterQuickPickItems = (commands: QuickActionCommandGroup[], search
 
   if (matchedCommands.length > 0) {
     return [ {
-      commands: matchedCommands
+      commands: matchedCommands.sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+        .map((item) => item.command)
     } ];
   }
 


### PR DESCRIPTION
## Problem
Filter on the context items doesn't sort expectedly. It should sort the items depending on their score and the higher score items should appear on top like the text starts with the match should be on top.

## Solution
Even though the scoring structure was working as expected, sorting was completely missing before sending back the filtered list. Sorting is added to filter function.

#### Result:
Now, even if the `ex-dom.ts` record is above the `dom.ts` and also the `files` group is above the `symbols` group which holds the `DomBuilder` record, the `dom.ts` and `DomBuilder` records will appear on top and `ex-dom.ts` will appear on bottom when the search term is `dom`.

<img width="508" alt="image" src="https://github.com/user-attachments/assets/61541efa-112c-4606-8674-9dbd5b01484f" />
<img width="668" alt="image" src="https://github.com/user-attachments/assets/0102bc26-5aba-4511-89e1-37521e657d1e" />

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
