### PR TITLE
fixed: wrong totalLines value in prompt input field

### DIFF
--- a/src/components/chat-item/prompt-input/prompt-text-input.ts
+++ b/src/components/chat-item/prompt-input/prompt-text-input.ts
@@ -487,17 +487,25 @@ export class PromptTextInput {
 
   public readonly getCursorLine = (): { cursorLine: number; totalLines: number } => {
     const lineHeight = parseFloat(window.getComputedStyle(this.promptTextInput, null).getPropertyValue('line-height'));
-    const totalLines = Math.floor(this.promptTextInput.scrollHeight / lineHeight);
     let cursorLine = -1;
     const cursorElm = DomBuilder.getInstance().build({
       type: 'span',
       classNames: [ 'cursor' ]
     });
+    const eolElm = DomBuilder.getInstance().build({
+      type: 'span',
+      classNames: [ 'eol' ]
+    });
+    this.promptTextInput.insertChild('beforeend', eolElm);
+
     this.insertElementToGivenPosition(cursorElm, this.getCursorPos(), undefined, true);
     if (cursorElm != null) {
       // find the cursor line position depending on line height
       cursorLine = Math.floor(((cursorElm as HTMLSpanElement).offsetTop + ((cursorElm as HTMLSpanElement).offsetHeight)) / lineHeight);
     }
+    const totalLines = Math.floor(((eolElm as HTMLSpanElement).offsetTop + ((eolElm as HTMLSpanElement).offsetHeight)) / lineHeight) ?? 0;
+    eolElm.remove();
+
     return {
       cursorLine,
       totalLines


### PR DESCRIPTION
## Problem
The incoming totalLines from the prompt input field is minimum 3 even if there is no text. And the currentLine and totalLines are not matching to trigger the down arrow button action which should grab the navigation history next item.

## Solution
Reason behind that was the new update on the min-height for the prompt input field as 3 lines height. The calculation of the totalLines is changed to calculate it through a pointer. Instead of checking the block height. It adds a new pointer to the end of the block and checks its position to calculate. When done, it removes the pointer.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
