### PR TITLE
fix: context item autoscrolls into view when in target

### DIFF
--- a/src/components/chat-item/prompt-input/prompt-input-quick-pick-item.ts
+++ b/src/components/chat-item/prompt-input/prompt-input-quick-pick-item.ts
@@ -73,6 +73,7 @@ export class PromptInputQuickPickItem {
   public readonly setFocus = (isFocused: boolean): void => {
     if (isFocused) {
       this.render.addClass('target-command');
+      this.render.scrollIntoView(true);
     } else {
       this.render.removeClass('target-command');
     }


### PR DESCRIPTION
## Problem
When a context item is out of the visible area of the overlay, keyboard navigation to that item doesn't scroll the parent to show the item on screen.
![image](https://github.com/user-attachments/assets/21c605e6-55d8-47d4-aca3-081361f51a02)

## Solution
Added scrollIntoView for the items when they're focused/in target by keyboard.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
