### PR TITLE
Dogusata/add autofocus to textual form items

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,17 +4,16 @@
 
 <!---
     REMINDER:
-    - Read CONTRIBUTING.md first.
-    - Add test coverage for your changes.
-    - Update the changelog using `npm run newChange`.
-    - Link to related issues/commits.
-    - Testing: how did you test your changes?
-    - Screenshots
+    - Read contributing and developer guidelines first.
+    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
+    - Add or update the documentation if applicable, this is mandatory
+    - Put screenshots if possible
 -->
 
 ## Tests
 - [ ] I have tested this change on VSCode
 - [ ] I have tested this change on JetBrains
+- [ ] I have added/updated the documentation (if applicable)
 
 ## License
 

--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -2195,6 +2195,7 @@ interface ChatItemFormItem {
   type: 'select' | 'textarea' | 'textinput' | 'numericinput' | 'stars' | 'radiogroup'; // type (see below for each of them)
   mandatory?: boolean; // If it is set to true, buttons in the same card with waitMandatoryFormItems set to true will wait them to be filled
   title?: string; // Label of the input
+  autoFocus: boolean; // focus to the input when it is created, default=> false. (Only for textual form items)
   description?: string; // The description, showing under the input field itself
   validationPatterns?: {
     operator?: 'and' | 'or';

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -122,6 +122,12 @@ export interface MynahUIProps {
     formData: Record<string, string>,
     tabId: string,
     eventId?: string) => void;
+    onFormTextualItemKeyPress?: (
+    event: KeyboardEvent,
+    formData: Record<string, string>,
+    itemId: string;
+    tabId: string,
+    eventId?: string) => boolean;
   onCustomFormAction?: (
     tabId: string,
     action: {
@@ -869,6 +875,39 @@ onFormModifierEnterPress?: (
       console.log(`Form modifier enter pressed on tab <b>${tabId}</b>:<br/>
       Form data: <b>${JSON.stringify(formData)}</b><br/>
       `);
+    },
+...
+```
+---
+
+### `onFormTextualItemKeyPress`
+
+This event will be fired when the user presses any key on their keyboard for textual form input items **if the form is valid**.
+
+**Important note**: 
+- This handler also expects a return as a boolean. If you return **`true`** then the form will be disabled including the following buttons. Also if they are in a custom form overlay panel, that panel will be closed. If you return **`false`**, everything will remain as is. 
+- Another important key point is having the `event` object as a KeyboardEvent. With that, you can prevent the default action of the keypress event. See the example below.
+
+
+```typescript
+...
+onFormTextualItemKeyPress?: (
+    event: KeyaboardEvent
+    formData: Record<string, string>,
+    itemId: string,
+    tabId: string,
+    eventId?: string): boolean => {
+      console.log(`Form keypress on tab <b>${tabId}</b>:<br/>
+      Item id: <b>${itemId}</b><br/>
+      Key: <b>${event.keyCode}</b><br/>
+      `);
+      if((itemId === 'description' || itemId === 'comment') && event.keyCode === 13 && event.ctrlKey !== true && event.shiftKey !== true) {
+        event.preventDefault(); // To stop default behavior
+        event.stopImmediatePropagation(); // To stop event to bubble to parent or other elements
+        // Do your magic, and submit your form data
+        return true; // return true to disable the form like a submit button do. It will also close the customForm overlay panel if the items are inside one.
+      }
+      return false; // Keep the form enabled and if applicable customForm overlay panel open
     },
 ...
 ```

--- a/example/src/connector.ts
+++ b/example/src/connector.ts
@@ -1,7 +1,7 @@
 import { ChatItem } from '@aws/mynah-ui';
 import { Log } from './logger';
 const STREAM_DELAY = 350;
-export const INITIAL_STREAM_DELAY = 1750;
+export const INITIAL_STREAM_DELAY = 1500;
 
 export class Connector {
   requestGenerativeAIAnswer = async (

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -440,6 +440,28 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
       Form data: <b>${JSON.stringify(formData)}</b><br/>
       `);
     },
+    onFormTextualItemKeyPress(event, formData, itemId, tabId) {
+      Log(`Form keypress on tab <b>${tabId}</b>:<br/>
+      Item id: <b>${itemId}</b><br/>
+      Key: <b>${event.keyCode}</b><br/>
+      `);
+      if((itemId === 'description' || itemId === 'comment') && event.keyCode === 13 && event.ctrlKey !== true && event.shiftKey !== true){
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        Log(`Form keypress Enter submit on tab <b>${tabId}</b>:<br/>
+          ${formData
+            ? `<br/>Options:<br/>${Object.keys(formData)
+              .map(optionId => {
+                return `<b>${optionId}</b>: ${(formData as Record<string, string>)[optionId] ?? ''}`;
+              })
+              .join('<br/>')}`
+            : ''
+          }
+          `);
+        return true
+      }
+      return false;
+    },
     onCustomFormAction: (tabId, action) => {
       Log(`Custom form action clicked for tab <b>${tabId}</b>:<br/>
       Action Id: <b>${action.id}</b><br/>
@@ -696,6 +718,7 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
           type: 'radiogroup',
           id: 'like',
           mandatory: true,
+          value: 'yes',
           options: [
             {
               label: 'Yes',
@@ -716,6 +739,8 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
           type: 'textarea',
           id: 'comment',
           title: 'Any comments?',
+          placeholder: 'Enter will submit the form if the form is filled and valid',
+          autoFocus: true,
         },
       ],
       [

--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -617,7 +617,7 @@ _To send the form, mandatory items should be filled._`,
                     pattern: /aws/gi
                 }]
             },
-            placeholder: 'Write your feelings about our tool',
+            placeholder: 'Write your feelings about our tool. If the form is fully filled and valid, Enter will submit the form',
         },
     ],
     buttons: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.23.0",
+    "version": "4.23.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.23.0",
+            "version": "4.23.1",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.23.0",
+    "version": "4.23.1",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/components/chat-item/chat-item-buttons.ts
+++ b/src/components/chat-item/chat-item-buttons.ts
@@ -17,6 +17,7 @@ export interface ChatItemButtonsWrapperProps {
   buttons: ChatItemButton[] | null;
   formItems?: ChatItemFormItemsWrapper | null;
   onActionClick?: (action: ChatItemButton, e?: Event) => void;
+  onAllButtonsDisabled?: () => void;
 }
 export class ChatItemButtonsWrapper {
   private readonly props: ChatItemButtonsWrapperProps;
@@ -64,8 +65,9 @@ export class ChatItemButtonsWrapper {
             }
             if (props.formItems != null) {
               props.formItems.disableAll();
+            } else {
+              this.disableAll();
             }
-            this.disableAll();
             if (this.props.onActionClick != null) {
               this.props.onActionClick(chatActionAction, e);
             }
@@ -86,6 +88,9 @@ export class ChatItemButtonsWrapper {
       props.formItems.onValidationChange = (isValid) => {
         this.handleValidationChange(isValid);
       };
+      props.formItems.onAllFormItemsDisabled = () => {
+        this.disableAll();
+      };
     }
   }
 
@@ -103,5 +108,6 @@ export class ChatItemButtonsWrapper {
         this.actions[chatActionId].element.setEnabled(false);
       }
     });
+    this.props.onAllButtonsDisabled?.();
   };
 }

--- a/src/components/chat-item/chat-item-form-items.ts
+++ b/src/components/chat-item/chat-item-form-items.ts
@@ -27,6 +27,7 @@ export class ChatItemFormItemsWrapper {
   private readonly validationItems: Record<string, boolean> = {};
   private isValid: boolean = false;
   onValidationChange?: (isValid: boolean) => void;
+  onAllFormItemsDisabled?: () => void;
 
   render: ExtendedHTMLElement;
   constructor (props: ChatItemFormItemsWrapperProps) {
@@ -100,8 +101,12 @@ export class ChatItemFormItemsWrapper {
             chatOption = new TextArea({
               testId: testIds.chatItem.chatItemForm.itemTextArea,
               label,
+              autoFocus: chatItemOption.autoFocus,
               description,
               fireModifierAndEnterKeyPress,
+              onKeyPress: (event) => {
+                this.handleTextualItemKeyPressEvent(event, chatItemOption.id);
+              },
               value,
               mandatory: chatItemOption.mandatory,
               validationPatterns: chatItemOption.validationPatterns,
@@ -113,8 +118,12 @@ export class ChatItemFormItemsWrapper {
             chatOption = new TextInput({
               testId: testIds.chatItem.chatItemForm.itemInput,
               label,
+              autoFocus: chatItemOption.autoFocus,
               description,
               fireModifierAndEnterKeyPress,
+              onKeyPress: (event) => {
+                this.handleTextualItemKeyPressEvent(event, chatItemOption.id);
+              },
               value,
               mandatory: chatItemOption.mandatory,
               validationPatterns: chatItemOption.validationPatterns,
@@ -126,8 +135,12 @@ export class ChatItemFormItemsWrapper {
             chatOption = new TextInput({
               testId: testIds.chatItem.chatItemForm.itemInput,
               label,
+              autoFocus: chatItemOption.autoFocus,
               description,
               fireModifierAndEnterKeyPress,
+              onKeyPress: (event) => {
+                this.handleTextualItemKeyPressEvent(event, chatItemOption.id);
+              },
               value,
               mandatory: chatItemOption.mandatory,
               validationPatterns: chatItemOption.validationPatterns,
@@ -140,8 +153,12 @@ export class ChatItemFormItemsWrapper {
             chatOption = new TextInput({
               testId: testIds.chatItem.chatItemForm.itemInput,
               label,
+              autoFocus: chatItemOption.autoFocus,
               description,
               fireModifierAndEnterKeyPress,
+              onKeyPress: (event) => {
+                this.handleTextualItemKeyPressEvent(event, chatItemOption.id);
+              },
               value,
               mandatory: chatItemOption.mandatory,
               validationPatterns: chatItemOption.validationPatterns,
@@ -189,6 +206,22 @@ export class ChatItemFormItemsWrapper {
     return {};
   };
 
+  private readonly handleTextualItemKeyPressEvent = (event: KeyboardEvent, itemId: string): void => {
+    if (this.isFormValid()) {
+      MynahUIGlobalEvents.getInstance().dispatch(MynahEventNames.FORM_TEXTUAL_ITEM_KEYPRESS, {
+        event,
+        formData: this.getAllValues(),
+        itemId,
+        tabId: this.props.tabId,
+        callback: (disableAll?: boolean) => {
+          if (disableAll === true) {
+            this.disableAll();
+          }
+        }
+      });
+    }
+  };
+
   private readonly isItemValid = (value: string, chatItemOption: ChatItemFormItem): boolean => {
     let validationState = true;
     if (chatItemOption.mandatory === true) {
@@ -215,6 +248,7 @@ export class ChatItemFormItemsWrapper {
 
   disableAll = (): void => {
     Object.keys(this.options).forEach(chatOptionId => this.options[chatOptionId].setEnabled(false));
+    this.onAllFormItemsDisabled?.();
   };
 
   getAllValues = (): Record<string, string> => {

--- a/src/components/feedback-form/custom-form.ts
+++ b/src/components/feedback-form/custom-form.ts
@@ -20,6 +20,7 @@ export interface CustomFormWrapperProps {
   title?: string;
   description?: string;
   onFormAction?: (actionName: string, formData: Record<string, string>) => void;
+  onFormDisabled?: () => void;
   onCloseButtonClick?: (e: Event) => void;
 }
 export class CustomFormWrapper {
@@ -90,6 +91,7 @@ export class CustomFormWrapper {
         tabId: this.props.tabId,
         formItems: this.chatFormItems,
         buttons: this.props.chatItem.buttons,
+        onAllButtonsDisabled: this.props.onFormDisabled,
         onActionClick: (action, e) => {
           if (e !== undefined) {
             cancelEvent(e);

--- a/src/components/feedback-form/feedback-form.ts
+++ b/src/components/feedback-form/feedback-form.ts
@@ -67,6 +67,9 @@ export class FeedbackForm {
                 chatItem: data.customFormData,
                 title: data.customFormData.title,
                 description: data.customFormData.description,
+                onFormDisabled: () => {
+                  this.close();
+                },
                 onFormAction: () => {
                   this.close();
                 },

--- a/src/components/form-items/text-area.ts
+++ b/src/components/form-items/text-area.ts
@@ -13,6 +13,7 @@ export interface TextAreaProps {
   classNames?: string[];
   attributes?: Record<string, string>;
   label?: HTMLElement | ExtendedHTMLElement | string;
+  autoFocus?: boolean;
   description?: ExtendedHTMLElement;
   mandatory?: boolean;
   fireModifierAndEnterKeyPress?: () => void;
@@ -23,6 +24,7 @@ export interface TextAreaProps {
   };
   value?: string;
   onChange?: (value: string) => void;
+  onKeyPress?: (event: KeyboardEvent) => void;
   testId?: string;
 }
 
@@ -50,11 +52,18 @@ export class TextAreaInternal extends TextAreaAbstract {
       type: 'textarea',
       testId: this.props.testId,
       classNames: [ 'mynah-form-input', ...(this.props.classNames ?? []) ],
-      attributes: this.props.placeholder !== undefined
-        ? {
-            placeholder: this.props.placeholder
-          }
-        : {},
+      attributes: {
+        ...(this.props.placeholder !== undefined
+          ? {
+              placeholder: this.props.placeholder
+            }
+          : {}),
+        ...(this.props.autoFocus === true
+          ? {
+              autofocus: 'autofocus'
+            }
+          : {}),
+      },
       events: {
         blur: (e) => {
           this.readyToValidate = true;
@@ -70,6 +79,9 @@ export class TextAreaInternal extends TextAreaAbstract {
           if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
             this.props.fireModifierAndEnterKeyPress?.();
           }
+        },
+        keypress: (e: KeyboardEvent) => {
+          this.props.onKeyPress?.(e);
         }
       },
     });
@@ -95,6 +107,12 @@ export class TextAreaInternal extends TextAreaAbstract {
         this.validationErrorBlock
       ]
     });
+
+    if (this.props.autoFocus === true) {
+      setTimeout(() => {
+        this.inputElement.focus();
+      }, 250);
+    }
   }
 
   setValue = (value: string): void => {

--- a/src/components/form-items/text-input.ts
+++ b/src/components/form-items/text-input.ts
@@ -13,6 +13,7 @@ export interface TextInputProps {
   classNames?: string[];
   attributes?: Record<string, string>;
   label?: HTMLElement | ExtendedHTMLElement | string;
+  autoFocus?: boolean;
   description?: ExtendedHTMLElement;
   mandatory?: boolean;
   fireModifierAndEnterKeyPress?: () => void;
@@ -24,6 +25,7 @@ export interface TextInputProps {
   };
   value?: string;
   onChange?: (value: string) => void;
+  onKeyPress?: (event: KeyboardEvent) => void;
   testId?: string;
 }
 
@@ -53,11 +55,16 @@ export class TextInputInternal extends TextInputAbstract {
       classNames: [ 'mynah-form-input', ...(this.props.classNames ?? []) ],
       attributes: {
         type: props.type ?? 'text',
-        ...(props.placeholder !== undefined
+        ...(this.props.placeholder !== undefined
           ? {
-              placeholder: props.placeholder
+              placeholder: this.props.placeholder
             }
-          : {})
+          : {}),
+        ...(this.props.autoFocus === true
+          ? {
+              autofocus: 'autofocus'
+            }
+          : {}),
       },
       events: {
         blur: (e) => {
@@ -74,6 +81,9 @@ export class TextInputInternal extends TextInputAbstract {
           if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
             this.props.fireModifierAndEnterKeyPress?.();
           }
+        },
+        keypress: (e: KeyboardEvent) => {
+          this.props.onKeyPress?.(e);
         }
       },
     });
@@ -99,6 +109,12 @@ export class TextInputInternal extends TextInputAbstract {
         this.validationErrorBlock
       ]
     });
+
+    if (this.props.autoFocus === true) {
+      setTimeout(() => {
+        this.inputElement.focus();
+      }, 250);
+    }
   }
 
   setValue = (value: string): void => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,6 +234,12 @@ export interface MynahUIProps {
     formData: Record<string, string>,
     tabId: string,
     eventId?: string) => void;
+  onFormTextualItemKeyPress?: (
+    event: KeyboardEvent,
+    formData: Record<string, string>,
+    itemId: string,
+    tabId: string,
+    eventId?: string) => boolean;
   onCustomFormAction?: (
     tabId: string,
     action: {
@@ -473,6 +479,18 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
     }) => {
       if (this.props.onFormModifierEnterPress !== undefined) {
         this.props.onFormModifierEnterPress(data.formData, data.tabId, this.getUserEventId());
+      }
+    });
+
+    MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.FORM_TEXTUAL_ITEM_KEYPRESS, (data: {
+      event: KeyboardEvent;
+      formData: Record<string, string>;
+      itemId: string;
+      tabId: string;
+      callback: (disableAll?: boolean) => void;
+    }) => {
+      if (this.props.onFormTextualItemKeyPress !== undefined) {
+        data.callback(this.props.onFormTextualItemKeyPress(data.event, data.formData, data.itemId, data.tabId, this.getUserEventId()));
       }
     });
 
@@ -943,7 +961,7 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
         description,
         buttons,
         formItems
-      }
+      },
     });
   };
 

--- a/src/static.ts
+++ b/src/static.ts
@@ -175,6 +175,7 @@ export enum MynahEventNames {
   TAB_FOCUS = 'tabFocus',
   CUSTOM_FORM_ACTION_CLICK = 'customFormActionClick',
   FORM_MODIFIER_ENTER_PRESS = 'formModifierEnterPress',
+  FORM_TEXTUAL_ITEM_KEYPRESS = 'formTextualItemKeyPress',
   ADD_ATTACHMENT = 'addAttachment',
   REMOVE_ATTACHMENT = 'removeAttachment',
   TAB_BAR_BUTTON_CLICK = 'tabBarButtonClick',
@@ -278,9 +279,6 @@ export interface ChatItemContent {
     actions?: Record<string, FileNodeAction[]>;
     details?: Record<string, TreeNodeDetails>;
   } | null;
-  /**
-   * @deprecated starting from version v5.0.0, it will no longer render the buttons in a reversed order, but rather in the order of the array.
-   */
   buttons?: ChatItemButton[] | null;
   formItems?: ChatItemFormItem[] | null;
   footer?: ChatItemContent | null;
@@ -327,6 +325,7 @@ interface BaseFormItem {
 
 export type TextBasedFormItem = BaseFormItem & {
   type: 'textarea' | 'textinput' | 'numericinput' | 'email';
+  autoFocus?: boolean;
   checkModifierEnterKeyPress?: boolean;
   validationPatterns?: {
     operator?: 'and' | 'or';


### PR DESCRIPTION
## Problem
- It requires mouse to focus on the first item in a form. 
- It is not possible to submit a form with enter keypress

## Solution
- Added `autoFocus` to textual form items, which focuses to the desired element after the form creation.
- Added `onFormTextualItemKeypress` event which sends the actual event object as an argument and expects a boolean return to handle the form enabled/disabled state and if applicable closing the customForm overlay panel.

<img width="328" alt="image" src="https://github.com/user-attachments/assets/e2f66e49-3fcb-4f29-9ebc-aa17c2ee59cd" />


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [X] I have tested this change on VSCode
- [X] I have tested this change on JetBrains
- [X] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
