### PR TITLE
Dogusata/context selector chevron visbility and target+hover+visual update

### DIFF
--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -170,8 +170,8 @@ export const mynahUIDefaults: Partial<MynahUITabStoreTab> = {
       {
         commands: [
           {
-            command: 'workspace',
-            icon: MynahIcons.ASTERISK,
+            command: '@workspace',
+            // icon: MynahIcons.ASTERISK,
             placeholder: 'Yes, you selected workspace :P',
             description: 'Reference all code in workspace.'
           },

--- a/src/components/chat-item/prompt-input/prompt-text-input.ts
+++ b/src/components/chat-item/prompt-input/prompt-text-input.ts
@@ -354,7 +354,7 @@ export class PromptTextInput {
     const contextSpanElement = DomBuilder.getInstance().build({
       type: 'span',
       children: [
-        ...(contextItem.icon != null ? [ new Icon({ icon: contextItem.icon }).render ] : []),
+        ...(contextItem.icon != null ? [ new Icon({ icon: contextItem.icon }).render ] : [ '@' ]),
         `${contextItem.command.replace(/^@?(.*)$/, '$1')}`
       ],
       classNames: [ 'context' ],

--- a/src/styles/components/chat/_chat-command-selector.scss
+++ b/src/styles/components/chat/_chat-command-selector.scss
@@ -130,7 +130,7 @@
     &:hover > .mynah-chat-command-selector-group > .mynah-chat-command-selector-command {
         &.target-command:not([disabled='true']):not(:hover) {
             background-color: transparent;
-            &:before{
+            &:before {
                 content: '';
                 position: absolute;
                 top: 0;

--- a/src/styles/components/chat/_chat-command-selector.scss
+++ b/src/styles/components/chat/_chat-command-selector.scss
@@ -124,11 +124,26 @@
                 grid-column: 2;
                 color: var(--mynah-color-text-weak);
             }
+        }
+    }
 
-            &:not(:hover):not(.target-command) {
-                > .mynah-chat-command-selector-command-arrow-icon {
-                    opacity: 0;
-                }
+    &:hover > .mynah-chat-command-selector-group > .mynah-chat-command-selector-command {
+        &.target-command:not([disabled='true']):not(:hover) {
+            background-color: transparent;
+            &:before{
+                content: '';
+                position: absolute;
+                top: 0;
+                left: 0;
+                box-sizing: border-box;
+                width: 100%;
+                height: 100%;
+                border: solid var(--mynah-button-border-width) var(--mynah-color-button);
+                border-radius: inherit;
+            }
+            &,
+            & * {
+                color: var(--mynah-color-text-default);
             }
         }
     }


### PR DESCRIPTION
## Problem
- Items with children in context selector is not clear until user hovers to them and see the right chevron that they have children
- When user keeps their mouse over the context selector block and uses keyboard up and down to target an element, it shows to focused items with the same weight.
- When an item is selected without an icon, it doesn't show the `@` character.

#### Before
<img width="701" alt="image" src="https://github.com/user-attachments/assets/570117b6-0fa8-45ae-b07b-e2cc8d33603d" />


## Solution
- Enabled the chevron to be visible all the time
- Added a hover check to the context selector overlay panel, if the panel is hovered then the target item will only be indicated with a border. It is still required since user may still hit enter from their keyboard. Even though the mouse target will be visually weighted more, users can still understand that the expected selection with keyboard enter will be the one with the border.
- Added `@` character if no icon is given for the context item.

#### After
https://github.com/user-attachments/assets/ba53b361-7930-4252-b074-2d12e6c93e73

<img width="626" alt="image" src="https://github.com/user-attachments/assets/60d3f0ec-4e16-4a63-8b7d-80aa119e79d8" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Tests
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
