### PR TITLE
Fixed modifier / ctrl input getting added to context search term

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -414,7 +414,7 @@ export class ChatPromptInput {
                   } else {
                     this.searchTerm = this.searchTerm.slice(0, -1);
                   }
-                } else if (e.key.length === 1) {
+                } else if ((!e.ctrlKey && !e.metaKey) && e.key.length === 1) {
                   this.searchTerm += e.key.toLowerCase();
                 }
                 this.filteredQuickPickItemGroups = filterQuickPickItems([ ...this.quickPickItemGroups ], this.searchTerm);


### PR DESCRIPTION
## Problem
Type @ to open the context menu. Type Cmd+A, keep hitting Cmd+A. Note that the list is filtered by "aaaa...".
Search should ignore inputs that use a modifier key. If the user hits Cmd+A, they are not looking to add "a" to the search string.

## Solution
Ctrl / modifier key combinations are not added to search term.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
