### PR TITLE
Fix cmd+a and deleting not closing context selector

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -409,7 +409,8 @@ export class ChatPromptInput {
               // In case the prompt is an incomplete regex
               try {
                 if (e.key === KeyMap.BACKSPACE) {
-                  if (this.searchTerm === '') {
+                  const isAllSelected = window.getSelection()?.toString() === this.promptTextInput.getTextInputValue();
+                  if (this.searchTerm === '' || isAllSelected) {
                     this.quickPick.close();
                   } else {
                     this.searchTerm = this.searchTerm.slice(0, -1);


### PR DESCRIPTION
## Problem
Type @ to open the menu. Use Cmd+A to select the entire prompt input and delete it. The menu stays open.

## Solution
Check if the selection in the prompt input is equal to the full input, if so, close the context selector.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
