### PR TITLE
fixed: spaces are not showing in context description

### DIFF
--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -264,7 +264,7 @@ export const mynahUIDefaults: Partial<MynahUITabStoreTab> = {
               }
             ],
             placeholder: 'Mention a specific file',
-            description: 'Reference a specific file'
+            description: 'Add a file to context'
 
           },
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.24.0",
+    "version": "4.24.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.24.0",
+            "version": "4.24.1",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.24.0",
+    "version": "4.24.1",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/components/chat-item/prompt-input/prompt-input-quick-pick-item.ts
+++ b/src/components/chat-item/prompt-input/prompt-input-quick-pick-item.ts
@@ -56,10 +56,10 @@ export class PromptInputQuickPickItem {
               classNames: [ 'mynah-chat-command-selector-command-description' ],
               children: [ {
                 type: 'span',
-                innerHTML: this.props.quickPickItem.description.slice(0, descriptionSplitPosition)
+                innerHTML: this.props.quickPickItem.description.slice(0, descriptionSplitPosition).replace(/ /g, '&nbsp;')
               }, {
                 type: 'span',
-                innerHTML: `<bdi>${this.props.quickPickItem.description.slice(descriptionSplitPosition)}</bdi>`
+                innerHTML: `<bdi>${this.props.quickPickItem.description.slice(descriptionSplitPosition).replace(/ /g, '&nbsp;')}</bdi>`
               } ]
             } ]
           : []),

--- a/src/styles/components/chat/_chat-command-selector.scss
+++ b/src/styles/components/chat/_chat-command-selector.scss
@@ -144,10 +144,11 @@
                     flex: 0 1 auto;
                     overflow: hidden;
                     max-height: var(--mynah-line-height);
+                    height: var(--mynah-line-height);
                 }
                 > span:first-child {
                     white-space: normal;
-                    word-break: break-all;
+                    word-break: break-word;
                     text-align: left;
                 }
 


### PR DESCRIPTION
## Problem
- In context or quick action command selector, sometimes spaces are not visible for the description.
![image](https://github.com/user-attachments/assets/bf54bac2-025b-4ef1-b75a-07f2a22a8d2b)

## Solution
- Replaced spaces of the string parts for description with `&nbsp;`. Since to be able to apply a middle ellipsis, we're splitting the text into two parts and wrap them with `span` elements. However, if the text end or start has a space character, it doesn't get rendered by default in html. To avoid it, we're replacing spaces with their char codes. It is not necessary to do a similar approach for any other character except space.

<img width="384" alt="Screenshot 2025-03-11 at 10 20 18" src="https://github.com/user-attachments/assets/00d2b8fb-7463-4e07-b818-244e16e10e36" />

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
