### PR TITLE
Added basic data model for InformationItem

### DIFF
--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -2769,16 +2769,17 @@ Information items can be rendered in an `InformationItemGroup` within the `chatI
 ```typescript
 export interface InformationItemGroup {
   title?: string;
-  informationItems: InformationItem[];
+  icon?: MynahIcons | MynahIconsType;
+  children: InformationItem[];
 }
 
 export interface InformationItem {
   messageId?: string;
   icon?: MynahIcons | MynahIconsType;
-  title: string;
+  title?: string;
   description?: string;
   actions?: ChatItemButton[];
   active?: boolean;
-  onClick?: () => void;
+  clickable?: boolean;
 }
 ```

--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -83,7 +83,7 @@ interface MynahUIDataModel {
   /**
   * List of chat item objects to be shown on the web suggestions search screen
   */
-  chatItems?: ChatItem[];
+  chatItems?: Array<ChatItem | InformationItemGroup>;
   /**
    * Attached code under the prompt input field
    */
@@ -855,6 +855,8 @@ mynahUI.updateStore('tab-1', {
 This is holding the chat items. If you provide it through the `defaults` or inside a tab item in the initial `tabs` property in the [Constructor properties](./PROPERTIES.md) you can give the whole set.
 
 **BUT** if you will set it through `updateStore` it will append the items in the list to the current chatItems list. In case if you need to update the list with a new one manually on runtime, you need to send an empty list first and than send the desired new list.
+
+ChatItems will either be of type `ChatItem` or `InformationItemGroup`. An `InformationItemGroup` can hold one or more `InformationItem` objects. This means that if you would like to just access the ChatItems in a tab, you should filter out the InformationItemGroups first.
 
 ```typescript
 const mynahUI = new MynahUI({
@@ -2755,5 +2757,28 @@ export interface ChatPrompt {
   escapedPrompt?: string; // Generally being used to send it back to mynah-ui for end user prompt rendering
   command?: string;
   context?: string[];
+}
+```
+
+---
+
+# `InformationItem`
+
+Information items can be rendered in an `InformationItemGroup` within the `chatItems?` array. These items are full width information displays, with an optional icon on the left, and room for a title, description, and a list of actions.
+
+```typescript
+export interface InformationItemGroup {
+  title?: string;
+  informationItems: InformationItem[];
+}
+
+export interface InformationItem {
+  messageId?: string;
+  icon?: MynahIcons | MynahIconsType;
+  title: string;
+  description?: string;
+  actions?: ChatItemButton[];
+  active?: boolean;
+  onClick?: () => void;
 }
 ```

--- a/src/components/chat-item/chat-item-card.ts
+++ b/src/components/chat-item/chat-item-card.ts
@@ -18,7 +18,7 @@ import { ChatItemFormItemsWrapper } from './chat-item-form-items';
 import { ChatItemButtonsWrapper, ChatItemButtonsWrapperProps } from './chat-item-buttons';
 import { cleanHtml } from '../../helper/sanitize';
 import { CONTAINER_GAP } from './chat-wrapper';
-import { chatItemHasContent } from '../../helper/chat-item';
+import { chatItemHasContent, isChatItem } from '../../helper/chat-item';
 import { Card } from '../card/card';
 import { ChatItemCardContent, ChatItemCardContentProps } from './chat-item-card-content';
 import testIds from '../../helper/test-ids';
@@ -543,7 +543,9 @@ export class ChatItemCard {
             .getTabDataStore(this.props.tabId)
             .updateStore(
               {
-                chatItems: currentTabChatItems?.map((chatItem: ChatItem) => {
+                chatItems: currentTabChatItems?.filter((chatItem): chatItem is ChatItem =>
+                  isChatItem(chatItem)
+                ).map((chatItem: ChatItem) => {
                   if (chatItem.messageId === this.props.chatItem.messageId) {
                     return this.props.chatItem;
                   }

--- a/src/helper/chat-item.ts
+++ b/src/helper/chat-item.ts
@@ -1,4 +1,4 @@
-import { ChatItem, ChatItemContent } from '../static';
+import { ChatItem, ChatItemContent, InformationItemGroup } from '../static';
 
 export const emptyChatItemContent: ChatItemContent = {
   header: null,
@@ -16,13 +16,17 @@ export const emptyChatItemContent: ChatItemContent = {
   tabbedContent: null
 };
 
+export function isChatItem (item: ChatItem | InformationItemGroup): item is ChatItem {
+  return 'type' in item;
+}
+
 export const chatItemHasContent = (chatItem: Partial<ChatItem>): boolean => (
   (chatItem.body != null && chatItem.body !== '') ||
-chatItem.fileList != null ||
-chatItem.formItems != null ||
-chatItem.customRenderer != null ||
-chatItem.informationCard != null ||
-chatItem.buttons != null);
+  chatItem.fileList != null ||
+  chatItem.formItems != null ||
+  chatItem.customRenderer != null ||
+  chatItem.informationCard != null ||
+  chatItem.buttons != null);
 
 export const copyToClipboard = async (
   textToSendClipboard: string,

--- a/src/helper/serialize-chat.ts
+++ b/src/helper/serialize-chat.ts
@@ -1,5 +1,7 @@
 import { ChatItemCard } from '../components/chat-item/chat-item-card';
 import { MynahUITabsStore } from './tabs-store';
+import { ChatItem } from '../static';
+import { isChatItem } from './chat-item';
 
 /**
  * Serialize all (non-empty) chat messages in a tab to a markdown string
@@ -7,7 +9,9 @@ import { MynahUITabsStore } from './tabs-store';
  * @returns The bodies of chat cards in markdown format, separated by \n\n---\n\n
  */
 export const serializeMarkdown = (tabId: string): string => {
-  return MynahUITabsStore.getInstance().getAllTabs()[tabId].store?.chatItems?.map(chatItem => chatItem.body ?? '').filter(chatItem => chatItem.trim() !== '').join('\n\n---\n\n') ?? '';
+  return MynahUITabsStore.getInstance().getAllTabs()[tabId].store?.chatItems?.filter((chatItem): chatItem is ChatItem =>
+    isChatItem(chatItem)
+  ).map(chatItem => chatItem.body ?? '').filter(chatItem => chatItem.trim() !== '').join('\n\n---\n\n') ?? '';
 };
 
 /**
@@ -16,7 +20,9 @@ export const serializeMarkdown = (tabId: string): string => {
  * @returns The bodies of chat cards in HTML format
  */
 export const serializeHtml = (tabId: string): string => {
-  const chatItemCardDivs = MynahUITabsStore.getInstance().getAllTabs()[tabId].store?.chatItems?.filter(chatItem => (chatItem.body != null) && chatItem.body.trim() !== '').map(chatItem => new ChatItemCard({
+  const chatItemCardDivs = MynahUITabsStore.getInstance().getAllTabs()[tabId].store?.chatItems?.filter((chatItem): chatItem is ChatItem =>
+    isChatItem(chatItem) && chatItem.body != null && chatItem.body.trim() !== ''
+  ).map(chatItem => new ChatItemCard({
     chatItem: {
       type: chatItem.type,
       body: chatItem.body,

--- a/src/static.ts
+++ b/src/static.ts
@@ -115,7 +115,7 @@ export interface MynahUIDataModel {
   /**
   * List of chat item objects to be shown on the web suggestions search screen
   */
-  chatItems?: ChatItem[];
+  chatItems?: Array<ChatItem | InformationItemGroup>;
   /**
    * Attached code under the prompt input field
    */
@@ -220,6 +220,21 @@ export enum ChatItemType {
   ANSWER_STREAM = 'answer-stream',
   ANSWER_PART = 'answer-part',
   CODE_RESULT = 'code-result',
+}
+
+export interface InformationItemGroup {
+  title?: string;
+  informationItems: InformationItem[];
+}
+
+export interface InformationItem {
+  messageId?: string;
+  icon?: MynahIcons | MynahIconsType;
+  title: string;
+  description?: string;
+  actions?: ChatItemButton[];
+  active?: boolean;
+  onClick?: () => void;
 }
 
 export type Status = 'info' | 'success' | 'warning' | 'error';

--- a/src/static.ts
+++ b/src/static.ts
@@ -224,17 +224,18 @@ export enum ChatItemType {
 
 export interface InformationItemGroup {
   title?: string;
-  informationItems: InformationItem[];
+  icon?: MynahIcons | MynahIconsType;
+  children: InformationItem[];
 }
 
 export interface InformationItem {
   messageId?: string;
   icon?: MynahIcons | MynahIconsType;
-  title: string;
+  title?: string;
   description?: string;
   actions?: ChatItemButton[];
   active?: boolean;
-  onClick?: () => void;
+  clickable?: boolean;
 }
 
 export type Status = 'info' | 'success' | 'warning' | 'error';


### PR DESCRIPTION
## Added
A data model for `InformationItem` and `InformationItemGroup`.

```typescript
export interface InformationItemGroup {
  title?: string;
  icon?: MynahIcons | MynahIconsType;
  children: InformationItem[];
}

export interface InformationItem {
  messageId?: string;
  icon?: MynahIcons | MynahIconsType;
  title?: string;
  description?: string;
  actions?: ChatItemButton[];
  active?: boolean;
  clickable?: boolean;
}
```

- `chatItems?` array on a tab can now contain either `ChatItem` objects or `InformationItemGroup` objects
- `InformationItemGroup` can optionally have a title to show above the group
- `InformationItem` must have a title, but can optionally have a description, be set to active to add a subtle background color, have a number of actions rendered on the right, and can have an onClick action on the whole item

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
