### PR TITLE
Jurredr/form input icons events

### DIFF
--- a/src/components/chat-item/chat-item-card.ts
+++ b/src/components/chat-item/chat-item-card.ts
@@ -325,7 +325,23 @@ export class ChatItemCard {
       this.chatFormItems = new ChatItemFormItemsWrapper({
         classNames: [ 'mynah-card-inner-order-40' ],
         tabId: this.props.tabId,
-        chatItem: this.props.chatItem
+        chatItem: this.props.chatItem,
+        onModifierEnterPress (formData, tabId) {
+          MynahUIGlobalEvents.getInstance().dispatch(MynahEventNames.FORM_MODIFIER_ENTER_PRESS, { formData, tabId });
+        },
+        onTextualItemKeyPress (event, itemId, formData, tabId, disableAllCallback) {
+          MynahUIGlobalEvents.getInstance().dispatch(MynahEventNames.FORM_TEXTUAL_ITEM_KEYPRESS, {
+            event,
+            formData,
+            itemId,
+            tabId,
+            callback: (disableAll?: boolean) => {
+              if (disableAll === true) {
+                disableAllCallback();
+              }
+            }
+          });
+        },
       });
       this.card?.render.insertChild('beforeend', this.chatFormItems.render);
     }

--- a/src/components/chat-item/chat-item-form-items.ts
+++ b/src/components/chat-item/chat-item-form-items.ts
@@ -5,10 +5,9 @@
 
 import { Config } from '../../helper/config';
 import { DomBuilder, ExtendedHTMLElement } from '../../helper/dom';
-import { MynahUIGlobalEvents } from '../../helper/events';
 import testIds from '../../helper/test-ids';
 import { isMandatoryItemValid, isTextualFormItemValid } from '../../helper/validator';
-import { ChatItem, ChatItemFormItem, MynahEventNames, TextBasedFormItem } from '../../static';
+import { ChatItem, ChatItemFormItem, TextBasedFormItem } from '../../static';
 import { RadioGroup } from '../form-items/radio-group';
 import { Select } from '../form-items/select';
 import { Stars } from '../form-items/stars';
@@ -20,6 +19,9 @@ export interface ChatItemFormItemsWrapperProps {
   tabId: string;
   chatItem: Partial<ChatItem>;
   classNames?: string[];
+  onModifierEnterPress?: (formData: Record<string, any>, tabId: string) => void;
+  onTextualItemKeyPress?: (event: KeyboardEvent, itemId: string, formData: Record<string, any>, tabId: string, disableAllCallback: () => void) => void;
+  onFormChange?: (formData: Record<string, any>, tabId: string) => void;
 }
 export class ChatItemFormItemsWrapper {
   private readonly props: ChatItemFormItemsWrapperProps;
@@ -67,7 +69,7 @@ export class ChatItemFormItemsWrapper {
         }
         const fireModifierAndEnterKeyPress = (): void => {
           if ((chatItemOption as TextBasedFormItem).checkModifierEnterKeyPress === true && this.isFormValid()) {
-            MynahUIGlobalEvents.getInstance().dispatch(MynahEventNames.FORM_MODIFIER_ENTER_PRESS, { formData: this.getAllValues(), tabId: props.tabId });
+            this.props.onModifierEnterPress?.(this.getAllValues(), props.tabId);
           }
         };
         const value = chatItemOption.value?.toString();
@@ -79,6 +81,7 @@ export class ChatItemFormItemsWrapper {
               label,
               description,
               value,
+              prefixIcon: chatItemOption.prefixIcon,
               options: chatItemOption.options,
               optional: chatItemOption.mandatory !== true,
               placeholder: Config.getInstance().config.texts.pleaseSelect,
@@ -105,7 +108,7 @@ export class ChatItemFormItemsWrapper {
               description,
               fireModifierAndEnterKeyPress,
               onKeyPress: (event) => {
-                this.handleTextualItemKeyPressEvent(event, chatItemOption.id);
+                this.isFormValid() && this.props.onTextualItemKeyPress?.(event, chatItemOption.id, this.getAllValues(), props.tabId, this.disableAll);
               },
               value,
               mandatory: chatItemOption.mandatory,
@@ -120,9 +123,10 @@ export class ChatItemFormItemsWrapper {
               label,
               autoFocus: chatItemOption.autoFocus,
               description,
+              prefixIcon: chatItemOption.prefixIcon,
               fireModifierAndEnterKeyPress,
               onKeyPress: (event) => {
-                this.handleTextualItemKeyPressEvent(event, chatItemOption.id);
+                this.isFormValid() && this.props.onTextualItemKeyPress?.(event, chatItemOption.id, this.getAllValues(), props.tabId, this.disableAll);
               },
               value,
               mandatory: chatItemOption.mandatory,
@@ -137,9 +141,10 @@ export class ChatItemFormItemsWrapper {
               label,
               autoFocus: chatItemOption.autoFocus,
               description,
+              prefixIcon: chatItemOption.prefixIcon,
               fireModifierAndEnterKeyPress,
               onKeyPress: (event) => {
-                this.handleTextualItemKeyPressEvent(event, chatItemOption.id);
+                this.isFormValid() && this.props.onTextualItemKeyPress?.(event, chatItemOption.id, this.getAllValues(), props.tabId, this.disableAll);
               },
               value,
               mandatory: chatItemOption.mandatory,
@@ -155,9 +160,10 @@ export class ChatItemFormItemsWrapper {
               label,
               autoFocus: chatItemOption.autoFocus,
               description,
+              prefixIcon: chatItemOption.prefixIcon,
               fireModifierAndEnterKeyPress,
               onKeyPress: (event) => {
-                this.handleTextualItemKeyPressEvent(event, chatItemOption.id);
+                this.isFormValid() && this.props.onTextualItemKeyPress?.(event, chatItemOption.id, this.getAllValues(), props.tabId, this.disableAll);
               },
               value,
               mandatory: chatItemOption.mandatory,
@@ -198,28 +204,13 @@ export class ChatItemFormItemsWrapper {
       this.validationItems[chatItemOption.id] = this.isItemValid(chatItemOption.value ?? '', chatItemOption);
       return {
         onChange: (value: string | number) => {
+          this.props.onFormChange?.(this.getAllValues(), this.props.tabId);
           this.validationItems[chatItemOption.id] = this.isItemValid(value.toString(), chatItemOption);
           this.isFormValid();
         }
       };
     }
     return {};
-  };
-
-  private readonly handleTextualItemKeyPressEvent = (event: KeyboardEvent, itemId: string): void => {
-    if (this.isFormValid()) {
-      MynahUIGlobalEvents.getInstance().dispatch(MynahEventNames.FORM_TEXTUAL_ITEM_KEYPRESS, {
-        event,
-        formData: this.getAllValues(),
-        itemId,
-        tabId: this.props.tabId,
-        callback: (disableAll?: boolean) => {
-          if (disableAll === true) {
-            this.disableAll();
-          }
-        }
-      });
-    }
   };
 
   private readonly isItemValid = (value: string, chatItemOption: ChatItemFormItem): boolean => {

--- a/src/components/feedback-form/custom-form.ts
+++ b/src/components/feedback-form/custom-form.ts
@@ -79,7 +79,26 @@ export class CustomFormWrapper {
       this.chatFormItems = null;
     }
     if (this.props.chatItem.formItems !== undefined) {
-      this.chatFormItems = new ChatItemFormItemsWrapper({ tabId: this.props.tabId, chatItem: this.props.chatItem });
+      this.chatFormItems = new ChatItemFormItemsWrapper({
+        tabId: this.props.tabId,
+        chatItem: this.props.chatItem,
+        onModifierEnterPress (formData, tabId) {
+          MynahUIGlobalEvents.getInstance().dispatch(MynahEventNames.FORM_MODIFIER_ENTER_PRESS, { formData, tabId });
+        },
+        onTextualItemKeyPress (event, itemId, formData, tabId, disableAllCallback) {
+          MynahUIGlobalEvents.getInstance().dispatch(MynahEventNames.FORM_TEXTUAL_ITEM_KEYPRESS, {
+            event,
+            formData,
+            itemId,
+            tabId,
+            callback: (disableAll?: boolean) => {
+              if (disableAll === true) {
+                disableAllCallback();
+              }
+            }
+          });
+        },
+      });
     }
 
     if (this.chatButtons !== null) {

--- a/src/components/form-items/radio-group.ts
+++ b/src/components/form-items/radio-group.ts
@@ -43,7 +43,7 @@ export class RadioGroupInternal extends RadioGroupAbstract {
     this.radioGroupElement = DomBuilder.getInstance().build({
       type: 'div',
       testId: props.wrapperTestId,
-      classNames: [ 'mynah-form-input', 'no-border', ...(props.classNames ?? []) ],
+      classNames: [ 'mynah-form-input', ...(props.classNames ?? []) ],
       children:
         props.options?.map((option, index) => ({
           type: 'div',
@@ -101,7 +101,7 @@ export class RadioGroupInternal extends RadioGroupAbstract {
         },
         {
           type: 'div',
-          classNames: [ 'mynah-form-input-container' ],
+          classNames: [ 'mynah-form-input-container', 'no-border' ],
           ...(props.attributes !== undefined ? { attributes: props.attributes } : {}),
           children: [
             this.radioGroupElement,

--- a/src/components/form-items/select.ts
+++ b/src/components/form-items/select.ts
@@ -5,7 +5,7 @@
 
 import { Config } from '../../helper/config';
 import { DomBuilder, DomBuilderObject, ExtendedHTMLElement } from '../../helper/dom';
-import { Icon, MynahIcons } from '../icon';
+import { Icon, MynahIcons, MynahIconsType } from '../icon';
 import '../../styles/components/_form-input.scss';
 
 interface SelectOption {
@@ -16,7 +16,8 @@ interface SelectOption {
 export interface SelectProps {
   classNames?: string[];
   attributes?: Record<string, string>;
-  icon?: MynahIcons;
+  icon?: MynahIcons | MynahIconsType;
+  prefixIcon?: MynahIcons | MynahIconsType;
   label?: HTMLElement | ExtendedHTMLElement | string;
   description?: ExtendedHTMLElement;
   value?: string;
@@ -81,6 +82,9 @@ export class SelectInternal {
           classNames: [ 'mynah-form-input-container' ],
           ...(props.attributes !== undefined ? { attributes: props.attributes } : {}),
           children: [
+            ...(props.prefixIcon
+              ? [ new Icon({ icon: props.prefixIcon, classNames: [ 'mynah-form-input-icon' ] }).render ]
+              : []),
             this.selectElement,
             new Icon({ icon: props.icon ?? MynahIcons.DOWN_OPEN, classNames: [ 'mynah-select-handle' ] }).render ]
         },

--- a/src/components/form-items/stars.ts
+++ b/src/components/form-items/stars.ts
@@ -65,12 +65,12 @@ export class Stars {
         },
         {
           type: 'div',
-          classNames: [ 'mynah-form-input-container' ],
+          classNames: [ 'mynah-form-input-container', 'no-border' ],
           ...(props.attributes !== undefined ? { attributes: props.attributes } : {}),
           children: [
             {
               type: 'div',
-              classNames: [ 'mynah-form-input', 'no-border', ...(props.classNames ?? []) ],
+              classNames: [ 'mynah-form-input', ...(props.classNames ?? []) ],
               children: [
                 this.starsContainer
               ]

--- a/src/components/form-items/text-input.ts
+++ b/src/components/form-items/text-input.ts
@@ -8,6 +8,7 @@ import { DomBuilder, ExtendedHTMLElement } from '../../helper/dom';
 import { checkTextElementValidation } from '../../helper/validator';
 import { ValidationPattern } from '../../static';
 import '../../styles/components/_form-input.scss';
+import { Icon, MynahIcons, MynahIconsType } from '../icon';
 
 export interface TextInputProps {
   classNames?: string[];
@@ -15,6 +16,7 @@ export interface TextInputProps {
   label?: HTMLElement | ExtendedHTMLElement | string;
   autoFocus?: boolean;
   description?: ExtendedHTMLElement;
+  prefixIcon?: MynahIcons | MynahIconsType;
   mandatory?: boolean;
   fireModifierAndEnterKeyPress?: () => void;
   placeholder?: string;
@@ -102,6 +104,9 @@ export class TextInputInternal extends TextInputAbstract {
           classNames: [ 'mynah-form-input-container' ],
           ...(props.attributes !== undefined ? { attributes: props.attributes } : {}),
           children: [
+            ...(props.prefixIcon
+              ? [ new Icon({ icon: props.prefixIcon, classNames: [ 'mynah-form-input-icon' ] }).render ]
+              : []),
             this.inputElement,
           ]
         },

--- a/src/static.ts
+++ b/src/static.ts
@@ -346,6 +346,7 @@ interface BaseFormItem {
   placeholder?: string;
   value?: string;
   description?: string;
+  prefixIcon?: MynahIcons | MynahIconsType;
 }
 
 export type TextBasedFormItem = BaseFormItem & {

--- a/src/styles/components/_form-input.scss
+++ b/src/styles/components/_form-input.scss
@@ -59,7 +59,7 @@
                 font-style: italic;
                 opacity: 0.5;
             }
-            
+
             -webkit-appearance: none;
             appearance: none;
             padding: 0;

--- a/src/styles/components/_form-input.scss
+++ b/src/styles/components/_form-input.scss
@@ -37,11 +37,18 @@
         box-sizing: border-box;
         justify-content: flex-end;
         align-items: center;
+        &:not(.no-border) {
+            padding: var(--mynah-sizing-3);
+            border: var(--mynah-border-width) solid var(--mynah-color-border-default);
+            background-color: var(--mynah-card-bg);
+            border-radius: var(--mynah-input-radius);
+        }
+
         > .mynah-form-input {
             width: 100%;
             left: 0;
             color: var(--mynah-color-text-default);
-            border-radius: var(--mynah-input-radius);
+
             &::placeholder {
                 color: var(--mynah-color-text-weak);
                 text-overflow: ellipsis;
@@ -52,13 +59,11 @@
                 font-style: italic;
                 opacity: 0.5;
             }
-            &:not(.no-border) {
-                padding: var(--mynah-sizing-3);
-                border: var(--mynah-border-width) solid var(--mynah-color-border-default);
-                background-color: var(--mynah-card-bg);
-            }
+            
             -webkit-appearance: none;
             appearance: none;
+            padding: 0;
+            border: none;
             text-indent: 1px;
             text-overflow: clip;
             outline: none;
@@ -176,11 +181,15 @@
             color: var(--mynah-color-text-input);
             outline: none;
         }
+        > .mynah-form-input-icon {
+            color: var(--mynah-color-text-weak);
+            margin-right: var(--mynah-sizing-2);
+        }
         > .mynah-select-handle {
             position: absolute;
             color: var(--mynah-color-text-weak);
             pointer-events: none;
-            transform: translateX(-100%);
+            transform: translateX(-25%);
         }
         & + .mynah-form-input-validation-error-block {
             display: flex;


### PR DESCRIPTION
## Added
- `prefixIcon` for all form items except for stars and radio group, an icon showing at the beginning:

![image](https://github.com/user-attachments/assets/a1ddfca2-371e-43c7-968d-40c91dd56633)

## Changed
- All global event dispatches from `chat-item-form-items` have been moved to callback handlers
- Added `onFormChange` event which is called every time anything in a form changes, regardless of validity

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
