### PR TITLE
fixed: data store, defaults and subscriber extensibility

### DIFF
--- a/src/__test__/main.spec.ts
+++ b/src/__test__/main.spec.ts
@@ -1,5 +1,5 @@
 import { MynahUITabsStore } from '../helper/tabs-store';
-import { ChatItemType, MynahUI } from '../main';
+import { ChatItemType, MynahUI, MynahUIDataModel } from '../main';
 
 const testTabId = 'tab-1';
 
@@ -76,5 +76,28 @@ describe('mynah-ui', () => {
 
     expect(cardElements[1].textContent).toBe('What is python');
     expect(cardElements[0].textContent).toBe('Amazon Q is generating your answer...');
+  });
+
+  it('does not break on data store extension', () => {
+    const testMynahUI = new MynahUI({
+      tabs: {
+        [testTabId]: {
+          isSelected: true,
+          store: {
+            loadingChat: false,
+          }
+        }
+      }
+    });
+
+    type ExtendedDataModel = MynahUIDataModel & { someOtherProperty: boolean };
+    const props: ExtendedDataModel = { someOtherProperty: true };
+
+    try {
+      testMynahUI.updateStore(testTabId, props);
+    } catch (e) {
+      console.log(e);
+      expect(true).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Problem
It is possible to extend data store, defaults and subscribers event though they are typed.

## Solution
Checking if the incoming key is available in the actual data model.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
