### PR TITLE
Added tab metadata field

### DIFF
--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -108,6 +108,12 @@ interface MynahUIDataModel {
    * Tab content header details, only visibile when showTabHeaderDetails is set to 'true'
    */
   tabHeaderDetails?: TabHeaderDetails | null;
+  /**
+   * A lightweight key-value store for essential tab-specific primitive metadata.
+   * Not intended for storing large amounts of data - use appropriate
+   * application state management for that purpose.
+   */
+  tabMetadata?: { [key: string]: string | boolean | number };
 }
 ```
 
@@ -906,6 +912,28 @@ mynahUI.updateStore('tab-1', {
   <br />
   <img src="./img/data-model/tabStore/tabHeaderDetails2.png" alt="tabHeaderDetails 2" style="max-width:500px; width:100%;border: 1px solid #e0e0e0;">
 </p>
+
+---
+
+### `tabMetaData` (default: `{}`)
+
+A lightweight key-value store for essential tab-specific metadata. Not intended for storing large amounts of data - use appropriate application state management for that purpose.
+
+```typescript
+const mynahUI = new MynahUI({
+    tabs: {
+        'tab-1': {
+            ...
+        }
+    }
+});
+
+mynahUI.updateStore('tab-1', {
+    tabMetaData: {
+      'test': 'hi'
+    }
+})
+```
 
 ---
 

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -145,8 +145,11 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
         isSelected: true,
         store: {
           ...mynahUIDefaults.store,
-          ...welcomeScreenTabData.store
-        }
+          ...welcomeScreenTabData.store,
+          tabMetaData: {
+            'test': 'hi'
+          }
+        },
       },
       'pinned-tab': {
         store: {

--- a/src/helper/store.ts
+++ b/src/helper/store.ts
@@ -36,6 +36,7 @@ const emptyDataModelObject: Required<MynahUIDataModel> = {
   tabBarButtons: [],
   compactMode: false,
   tabHeaderDetails: null,
+  tabMetadata: {}
 };
 const dataModelKeys = Object.keys(emptyDataModelObject);
 export class EmptyMynahUIDataModel {

--- a/src/static.ts
+++ b/src/static.ts
@@ -140,6 +140,12 @@ export interface MynahUIDataModel {
    * Tab content header details, only visibile when showTabHeaderDetails is set to 'true'
    */
   tabHeaderDetails?: TabHeaderDetails | null;
+  /**
+   * A lightweight key-value store for essential tab-specific primitive metadata.
+   * Not intended for storing large amounts of data - use appropriate
+   * application state management for that purpose.
+   */
+  tabMetadata?: { [key: string]: string | boolean | number };
 }
 
 export interface MynahUITabStoreTab {
@@ -340,7 +346,7 @@ export interface ChatItemContent {
   codeBlockActions?: CodeBlockActions | null;
 }
 
-export interface ChatItem extends ChatItemContent{
+export interface ChatItem extends ChatItemContent {
   type: ChatItemType;
   messageId?: string;
   snapToTop?: boolean;


### PR DESCRIPTION
## Problem
There are some use cases in which custom data related to a tab needs to be defined by consumers of MynahUI. For simple use cases, it is excessive to have them create and maintain a separate store keyed on tab id's just to store this metadata.

## Solution
Introduced a new `tabMetadata` field on the tab data model, which is an object with key/value pairs, where the key is a string and the value is a primitive (boolean / string / number).

```typescript
const mynahUI = new MynahUI({
    tabs: {
        'tab-1': {
            ...
        }
    }
});

mynahUI.updateStore('tab-1', {
    tabMetaData: {
      'test': 'hi'
    }
})
```

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [x] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
