### PR TITLE
Fixed form input bg color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.26.0",
+    "version": "4.26.1",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/styles/components/_detailed-list.scss
+++ b/src/styles/components/_detailed-list.scss
@@ -2,7 +2,6 @@
 .mynah-detailed-list {
     display: flex;
     box-sizing: border-box;
-    background-color: var(--mynah-card-bg);
     border-radius: var(--mynah-card-radius);
     width: 100%;
     pointer-events: all;

--- a/src/styles/components/_form-input.scss
+++ b/src/styles/components/_form-input.scss
@@ -54,15 +54,13 @@
                 z-index: -1;
                 opacity: 10%;
             }
-            > .mynah-form-input {
-                background-color: transparent;
-            }
         }
 
         > .mynah-form-input {
             width: 100%;
             left: 0;
             color: var(--mynah-color-text-default);
+            background-color: transparent;
 
             &[disabled] {
                 pointer-events: none;


### PR DESCRIPTION
## Problem
Form (text) input background colors do not adapt to theming colors properly;
![image](https://github.com/user-attachments/assets/fb162ec2-db82-48f7-8f06-ffb1b3abb850)

## Solution
Make the input itself transparent.
![Screenshot 2025-03-28 at 12 05 43](https://github.com/user-attachments/assets/a266afb0-f1b8-4b21-a760-4311bf8e2720)

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
