### PR TITLE
Fixed HTML export being in reverse order with incorrect transforms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.27.1",
+    "version": "4.28.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.27.1",
+            "version": "4.28.0",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.27.1",
+    "version": "4.28.0",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/helper/serialize-chat.ts
+++ b/src/helper/serialize-chat.ts
@@ -28,7 +28,7 @@ export const serializeHtml = (tabId: string): string => {
       icon: chatItem.icon
     },
     tabId,
-  }).render.outerHTML).reverse().join('\n');
+  }).render.outerHTML).join('\n');
 
   // Get all relevant styles from the document
   const styleSheets = Array.from(document.styleSheets);
@@ -44,7 +44,7 @@ export const serializeHtml = (tabId: string): string => {
                 ruleText = `.mynah-chat-wrapper { display: block !important; ${rule.style.cssText} }`;
               }
               if (rule.selectorText.includes('.mynah-chat-item-card')) {
-                ruleText = rule.cssText.replace('opacity: 0', 'opacity: 1').replace('transform: translate3d(0px, min(50%, 25vh), 0px) scale(0.95, 1.25)', 'transform: none');
+                ruleText = rule.cssText.replace('opacity: 0', 'opacity: 1').replace('transform: translate3d(0px, min(30%, 10vh), 0px) scale(0.99)', 'transform: none');
               }
               if (rule.selectorText.includes('.mynah-syntax-highlighter-copy-buttons')) {
                 ruleText = rule.cssText.replace('display: flex', 'display: none');
@@ -70,7 +70,7 @@ export const serializeHtml = (tabId: string): string => {
       </head>
       <body>
       <div class="mynah-chat-wrapper" style="max-width: 600px; overflow-y: scroll; margin: auto; border: 1px solid gray;">
-        <div class="mynah-chat-items-container">${chatItemCardDivs ?? ''}</div>
+        <div class="mynah-chat-items-container" style="padding: 10px;">${chatItemCardDivs ?? ''}</div>
         </div>
       </body>
     </html>


### PR DESCRIPTION
## Problem
The HTML serialization for tabs was broken after the new changes to scroll behavior. The order of exported chat items was incorrect, and their position was off as well:
<img width="500" src="https://github.com/user-attachments/assets/10b87ad8-1ac9-4ee2-9a2b-d50a64ee123c" />

## Solution
Fixed the transform and undid reversing the list:
<img width="500" src="https://github.com/user-attachments/assets/bc58e6bb-5d42-4c77-a2ad-d37c3f2181ae" />

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
