### PR TITLE
fix: padding of sticky card

### DIFF
--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -379,7 +379,8 @@
 
 > .mynah-chat-prompt-input-sticky-card {
     &:not(:empty) {
-        padding-top: var(--mynah-sizing-4);
+        padding: var(--mynah-sizing-4);
+        padding-bottom: 0;
     }
 
     > .mynah-chat-item-card {


### PR DESCRIPTION
## Problem
Padding is broken for the sticky card
<img width="650" alt="image" src="https://github.com/user-attachments/assets/cfaf6a74-5167-47ce-bfa3-5bffa16a7966" />

## Solution
- Fixed padding of sticky card
<img width="736" alt="image" src="https://github.com/user-attachments/assets/8e0988c3-8cb1-4bd9-a9f4-f37cfc5f7e1b" />

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
