### PR TITLE
Updated export icon to correct version

### DIFF
--- a/src/components/icon/icons/external.svg
+++ b/src/components/icon/icons/external.svg
@@ -1,15 +1,4 @@
 <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<g clip-path="url(#clip0_426_2363)">
-		<path d="M7.5 1.5H10.5V4.5" stroke="white" stroke-width="2" stroke-miterlimit="10"
-			stroke-linecap="square" />
-		<path d="M4.5 7.5L10.5 1.5" stroke="white" stroke-width="2" stroke-miterlimit="10" />
-		<path d="M10.5 6.786V10.5H1.5V1.5H5.25" stroke="white" stroke-width="2"
-			stroke-linejoin="round" />
-	</g>
-	<defs>
-		<clipPath id="clip0_426_2363">
-			<rect width="12" height="12" fill="white" />
-		</clipPath>
-	</defs>
+<path d="M7.75 1.75H10.75M10.75 1.75V4.75M10.75 1.75L5.75 6.75" stroke="white" stroke-miterlimit="10" stroke-linecap="square"/>
+<path d="M10.75 7.036V10.75H1.75V1.75H5.5" stroke="white" stroke-linejoin="round"/>
 </svg>
-	


### PR DESCRIPTION
## Problem
Export icon was too bold.

## Solution
Swapped out the icon for the correct one.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
