### PR TITLE
Removed tabId from sheet props, fixed tabButtons disappearing

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -419,7 +419,6 @@ The function provides a couple of callbacks which can be used to control the she
 
 ```typescript
 const { update, close, changeTarget, getTargetElementId } = mynahUI.openDetailedList({
-    tabId,
     detailedList: {}, // The DetailedList, for the data model check DATAMODEL.md
     events: {
       onFilterValueChange: (filterValues: Record<string, any>, isValid: boolean) => {

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -228,7 +228,6 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
         });
       } else if (buttonId === 'history_sheet') {
         const { update, close, changeTarget, getTargetElementId } = mynahUI.openDetailedList({
-          tabId,
           detailedList:
           {
             header: {
@@ -533,7 +532,6 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
         });
       } else if (buttonId === 'memory_sheet') {
         const { close, update, changeTarget } = mynahUI.openDetailedList({
-          tabId,
           detailedList:
           {
             header: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.30.0",
+    "version": "4.30.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.30.0",
+            "version": "4.30.1",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.30.0",
+    "version": "4.30.1",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/components/detailed-list/detailed-list-sheet.ts
+++ b/src/components/detailed-list/detailed-list-sheet.ts
@@ -3,7 +3,6 @@ import { ChatItemButton, DetailedList, DetailedListItem, MynahEventNames } from 
 import { DetailedListWrapper } from './detailed-list';
 
 export interface DetailedListSheetProps {
-  tabId: string;
   detailedList: DetailedList;
   events?: {
     onFilterValueChange?: (filterValues: Record<string, any>, isValid: boolean) => void;
@@ -36,7 +35,6 @@ export class DetailedListSheet {
 
   open = (): void => {
     MynahUIGlobalEvents.getInstance().dispatch(MynahEventNames.OPEN_SHEET, {
-      tabId: this.props.tabId,
       fullScreen: true,
       title: this.props.detailedList.header?.title,
       description: this.props.detailedList.header?.description,

--- a/src/components/detailed-list/detailed-list-sheet.ts
+++ b/src/components/detailed-list/detailed-list-sheet.ts
@@ -3,6 +3,7 @@ import { ChatItemButton, DetailedList, DetailedListItem, MynahEventNames } from 
 import { DetailedListWrapper } from './detailed-list';
 
 export interface DetailedListSheetProps {
+  tabId?: string; // TODO: remove this in new major version, still here for backwards compatibility
   detailedList: DetailedList;
   events?: {
     onFilterValueChange?: (filterValues: Record<string, any>, isValid: boolean) => void;

--- a/src/components/sheet.ts
+++ b/src/components/sheet.ts
@@ -12,7 +12,6 @@ import { Icon } from './icon';
 import { CardBody } from './card/card-body';
 
 export interface SheetProps {
-  tabId: string;
   title?: string;
   children?: Array<ExtendedHTMLElement | HTMLElement | string | DomBuilderObject>;
   fullScreen?: boolean;

--- a/src/helper/tabs-store.ts
+++ b/src/helper/tabs-store.ts
@@ -73,16 +73,18 @@ export class MynahUITabsStore {
   };
 
   public readonly removeTab = (tabId: string): string => {
+    const wasSelected = this.tabsStore[tabId].isSelected ?? false;
     let newSelectedTab: MynahUITabStoreTab | undefined;
     delete this.tabsStore[tabId];
     this.tabsDataStore[tabId].resetStore();
     delete this.tabsDataStore[tabId];
-    const tabIds = Object.keys(this.tabsStore);
-    // Refresh the tab selection
-    if (tabIds.length > 0) {
-      this.deselectAllTabs();
-      this.selectTab(tabIds[tabIds.length - 1]);
-      newSelectedTab = this.tabsStore[this.getSelectedTabId()];
+    if (wasSelected) {
+      const tabIds = Object.keys(this.tabsStore);
+      if (tabIds.length > 0) {
+        this.deselectAllTabs();
+        this.selectTab(tabIds[tabIds.length - 1]);
+        newSelectedTab = this.tabsStore[this.getSelectedTabId()];
+      }
     }
     this.informSubscribers('remove', tabId, newSelectedTab);
     return tabId;

--- a/src/helper/tabs-store.ts
+++ b/src/helper/tabs-store.ts
@@ -73,18 +73,16 @@ export class MynahUITabsStore {
   };
 
   public readonly removeTab = (tabId: string): string => {
-    const wasSelected = this.tabsStore[tabId].isSelected ?? false;
     let newSelectedTab: MynahUITabStoreTab | undefined;
     delete this.tabsStore[tabId];
     this.tabsDataStore[tabId].resetStore();
     delete this.tabsDataStore[tabId];
-    if (wasSelected) {
-      const tabIds = Object.keys(this.tabsStore);
-      if (tabIds.length > 0) {
-        this.deselectAllTabs();
-        this.selectTab(tabIds[tabIds.length - 1]);
-        newSelectedTab = this.tabsStore[this.getSelectedTabId()];
-      }
+    const tabIds = Object.keys(this.tabsStore);
+    // Refresh the tab selection
+    if (tabIds.length > 0) {
+      this.deselectAllTabs();
+      this.selectTab(tabIds[tabIds.length - 1]);
+      newSelectedTab = this.tabsStore[this.getSelectedTabId()];
     }
     this.informSubscribers('remove', tabId, newSelectedTab);
     return tabId;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1003,7 +1003,6 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
       getTargetElementId: () => string | undefined;
     } => {
     const detailedListSheet = new DetailedListSheet({
-      tabId: data.tabId,
       detailedList: data.detailedList,
       events: data.events
     });


### PR DESCRIPTION
## Problem
- There was an unused `tabId` prop in the Sheet component and `openDetailedList()` function.
- Tab buttons would disappear when closing a tab in the tab bar which was currently not open.

## Solution
- Remove the unused `tabId` prop from the internal Sheet component, made it optional but left it in the `openDetailedList()` function for backwards compatibility.
- Always refresh the selected tab and the bar itself whenever a tab is removed, to ensure the buttons are always rendered accordingly.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [x] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
