### PR TITLE
fixed: codeBlock and inline code autoheight issues

### DIFF
--- a/src/components/__test__/syntax-highlighter.spec.ts
+++ b/src/components/__test__/syntax-highlighter.spec.ts
@@ -9,7 +9,7 @@ describe('syntax-highlighter', () => {
     });
 
     expect(testSyntaxHighlighter.render.outerHTML.replace('\n', '')).toBe(
-      '<div class="mynah-syntax-highlighter"><pre><code class="language-js hljs language-javascript" data-highlighted="yes"><span class="hljs-title function_">alert</span>(<span class="hljs-string">"hello"</span>);</code></pre><div class="mynah-syntax-highlighter-copy-buttons"><span class="mynah-syntax-highlighter-language">js</span></div></div>'
+      '<div class="mynah-syntax-highlighter"><pre><code class="language-js hljs language-javascript" data-highlighted="yes"><span class="hljs-title function_">alert</span>(<span class="hljs-string">"hello"</span>);</code></pre><div class="more-content-indicator"><button class="mynah-button mynah-button-secondary fill-state-hover mynah-ui-clickable-item" tabindex="0"><i class="mynah-ui-icon mynah-ui-icon-down-open"></i></button></div><div class="mynah-syntax-highlighter-copy-buttons"><span class="mynah-syntax-highlighter-language">js</span></div></div>'
     );
   });
 
@@ -31,8 +31,8 @@ describe('syntax-highlighter', () => {
       onCodeBlockAction: () => {},
       block: true,
     });
-    expect(testSyntaxHighlighter.render.querySelectorAll('button')?.length).toBe(2);
-    expect(testSyntaxHighlighter.render.querySelectorAll('button')?.[0]?.textContent).toBe('Copy');
-    expect(testSyntaxHighlighter.render.querySelectorAll('button')?.[1]?.textContent).toBe('Insert at cursor');
+    expect(testSyntaxHighlighter.render.querySelectorAll('button')?.length).toBe(3);
+    expect(testSyntaxHighlighter.render.querySelectorAll('button')?.[1]?.textContent).toBe('Copy');
+    expect(testSyntaxHighlighter.render.querySelectorAll('button')?.[2]?.textContent).toBe('Insert at cursor');
   });
 });

--- a/src/components/syntax-highlighter.ts
+++ b/src/components/syntax-highlighter.ts
@@ -142,11 +142,29 @@ export class SyntaxHighlighter {
       });
     }
 
+    const moreContentIndicator = new MoreContentIndicator({
+      icon: MynahIcons.DOWN_OPEN,
+      border: false,
+      onClick: () => {
+        if (this.render.hasClass('no-max')) {
+          this.render.removeClass('no-max');
+          moreContentIndicator.update({
+            icon: MynahIcons.DOWN_OPEN
+          });
+        } else {
+          this.render.addClass('no-max');
+          moreContentIndicator.update({
+            icon: MynahIcons.UP_OPEN
+          });
+        }
+      }
+    });
     this.render = DomBuilder.getInstance().build({
       type: 'div',
       testId: testIds.chatItem.syntaxHighlighter.wrapper,
       classNames: [ 'mynah-syntax-highlighter',
-        ...(props.block !== true ? [ 'mynah-inline-code' ] : []),
+        ...(props.block !== true ? [ 'mynah-inline-code' ] : [ ]),
+        ...(props.unlimitedHeight === true ? [ 'no-max' ] : [ ]),
       ],
       children: [
         preElement,
@@ -163,50 +181,35 @@ export class SyntaxHighlighter {
               }
             ]
           : []),
-        {
-          type: 'div',
-          testId: testIds.chatItem.syntaxHighlighter.buttonsWrapper,
-          classNames: [ 'mynah-syntax-highlighter-copy-buttons' ],
-          children: [
-            ...this.codeBlockButtons,
-            ...(props.language != null && this.props.hideLanguage !== true
-              ? [ {
-                  type: 'span',
-                  testId: testIds.chatItem.syntaxHighlighter.language,
-                  classNames: [ 'mynah-syntax-highlighter-language' ],
-                  children: [ props.language.replace('diff-', '') ]
-                } ]
-              : []),
-          ],
-        }
+        ...(this.props.block === true
+          ? [
+              ...(this.props.unlimitedHeight !== true ? [ moreContentIndicator.render ] : []),
+              {
+                type: 'div',
+                testId: testIds.chatItem.syntaxHighlighter.buttonsWrapper,
+                classNames: [ 'mynah-syntax-highlighter-copy-buttons' ],
+                children: [
+                  ...this.codeBlockButtons,
+                  ...(props.language != null && this.props.hideLanguage !== true
+                    ? [ {
+                        type: 'span',
+                        testId: testIds.chatItem.syntaxHighlighter.language,
+                        classNames: [ 'mynah-syntax-highlighter-language' ],
+                        children: [ props.language.replace('diff-', '') ]
+                      } ]
+                    : []),
+                ],
+              }
+            ]
+          : [])
       ]
     });
 
     setTimeout(() => {
-      if (this.props.unlimitedHeight !== true && preElement.scrollHeight > preElement.clientHeight) {
-        const moreContentIndicator = new MoreContentIndicator({
-          icon: MynahIcons.DOWN_OPEN,
-          border: false,
-          onClick: () => {
-            if (this.render.hasClass('no-max')) {
-              this.render.removeClass('no-max');
-              moreContentIndicator.update({
-                icon: MynahIcons.DOWN_OPEN
-              });
-            } else {
-              this.render.addClass('no-max');
-              moreContentIndicator.update({
-                icon: MynahIcons.UP_OPEN
-              });
-            }
-          }
-        });
+      if (this.props.block === true && this.props.unlimitedHeight !== true && preElement.scrollHeight > preElement.clientHeight) {
         this.render.addClass('max-height-exceed');
-        this.render.insertAdjacentElement('beforeend', moreContentIndicator.render);
-      } else {
-        this.render.addClass('no-max');
       }
-    }, 1);
+    }, 100);
   }
 
   private readonly getSelectedCodeContextMenu = (): {

--- a/src/helper/dom.ts
+++ b/src/helper/dom.ts
@@ -405,6 +405,10 @@ export const getTypewriterPartsCss = (
 
 export const cleanupElement = (elm: HTMLElement): void => {
   if (elm.querySelectorAll !== undefined) {
-    Array.from(elm.querySelectorAll('*:empty:not([class]:not([class=""]), img, br, hr, input[type="checkbox"])')).forEach(emptyElement => { emptyElement.remove(); });
+    Array.from(elm.querySelectorAll('*:empty:not(img, br, hr, input[type="checkbox"])')).forEach(emptyElement => {
+      if (emptyElement.classList.length === 0) {
+        emptyElement.remove();
+      }
+    });
   }
 };

--- a/src/helper/dom.ts
+++ b/src/helper/dom.ts
@@ -405,6 +405,6 @@ export const getTypewriterPartsCss = (
 
 export const cleanupElement = (elm: HTMLElement): void => {
   if (elm.querySelectorAll !== undefined) {
-    Array.from(elm.querySelectorAll('*:empty:not(img, br, hr, input[type="checkbox"])')).forEach(emptyElement => { emptyElement.remove(); });
+    Array.from(elm.querySelectorAll('*:empty:not([class]:not([class=""]), img, br, hr, input[type="checkbox"])')).forEach(emptyElement => { emptyElement.remove(); });
   }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -805,8 +805,6 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
         });
         this.chatWrappers[tabId].updateLastChatAnswer(updateWith);
       }
-
-      console.log(MynahUITabsStore.getInstance().getTabDataStore(tabId).getValue('chatItems'));
     }
   };
 

--- a/src/styles/components/_more-content-indicator.scss
+++ b/src/styles/components/_more-content-indicator.scss
@@ -1,6 +1,5 @@
 .more-content-indicator {
     position: relative;
-    transition: var(--mynah-very-short-transition);
     padding: var(--mynah-sizing-4);
     pointer-events: none;
     opacity: 1;

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -16,7 +16,6 @@
     border-radius: var(--mynah-input-radius);
     line-height: var(--mynah-syntax-code-line-height);
     color: var(--mynah-color-text-default);
-    max-height: var(--mynah-syntax-code-block-max-height);
 
     &:before,
     & > .line-numbers-rows:before {
@@ -44,6 +43,9 @@
         margin-block: 0 !important;
         position: relative;
         border-top: 1px solid var(--mynah-color-border-default);
+        &:empty {
+            display: none;
+        }
         &:before {
             content: '';
             position: absolute;
@@ -126,12 +128,29 @@
             background-color: var(--mynah-color-syntax-bg);
         }
     }
+    &:not(.mynah-inline-code) {
+        > pre {
+            max-height: var(--mynah-syntax-code-block-max-height);
+            $listFader: linear-gradient(
+                to bottom,
+                black 0%,
+                black calc(1 * (var(--mynah-syntax-code-block-max-height) - (2 * var(--mynah-sizing-10)))),
+                transparent calc(1 * (var(--mynah-syntax-code-block-max-height) - (var(--mynah-sizing-10)))),
+                transparent 100%
+            );
+            -webkit-mask-image: $listFader;
+            -webkit-mask-size: 100% 100%;
+            mask-image: $listFader;
+            mask-size: 100% 100%;
+        }
+    }
     > pre {
         padding: var(--mynah-sizing-2);
+        position: relative;
         margin: 0;
         overflow-x: auto;
-        overflow-y: hidden;
-        position: relative;
+        overflow-y: scroll;
+        box-sizing: border-box;
 
         *,
         & {
@@ -297,17 +316,16 @@
         }
     }
 
-    &.max-height-exceed {
-        > pre {
-            overflow-y: auto;
-            padding-bottom: var(--mynah-sizing-4);
-            @include list-fader-bottom();
-        }
-    }
     > .more-content-indicator {
+        position: absolute;
+        top: var(--mynah-syntax-code-block-max-height);
+        left: 0;
+        width: 100%;
         padding: var(--mynah-sizing-half);
         justify-content: center;
-        height: auto;
+        height: var(--mynah-sizing-10);
+        box-sizing: border-box;
+        transform: translateY(-100%);
         margin-top: 0;
         box-shadow: none;
         background-color: var(--mynah-card-bg);
@@ -328,9 +346,23 @@
     }
 
     &.no-max {
-        max-height: initial;
         > pre {
+            max-height: initial;
             overflow-y: hidden;
+            padding-bottom: var(--mynah-sizing-2);
+            -webkit-mask-image: none;
+            mask-image: none;
+        }
+        > .more-content-indicator {
+            position: relative;
+            top: initial;
+            transform: translateY(0);
+        }
+    }
+
+    &.max-height-exceed:not(.no-max, .mynah-inline-code) {
+        > pre {
+            padding-bottom: var(--mynah-sizing-13);
         }
     }
 }

--- a/ui-tests/__test__/flows/markdown-parser/markdown-parser.ts
+++ b/ui-tests/__test__/flows/markdown-parser/markdown-parser.ts
@@ -77,8 +77,8 @@ export const parseMarkdown = async (page: Page, skipScreenshots?: boolean): Prom
 
   // Code blocks
   expect(await answerCard.evaluate(node => node.querySelectorAll('pre > code')[0]?.innerHTML)).toBe('inline code');
-  expect(await answerCard.evaluate(node => node.querySelectorAll('pre')[2]?.nextElementSibling?.querySelector(':scope > span')?.innerHTML)).toBe('javascript');
-  expect(await answerCard.evaluate(node => node.querySelectorAll('pre')[2]?.nextElementSibling?.querySelector(':scope > button')?.querySelector(':scope > span')?.innerHTML)).toBe('Copy');
+  expect(await answerCard.evaluate(node => node.querySelectorAll('pre')[2]?.nextElementSibling?.nextElementSibling?.querySelector(':scope > span')?.innerHTML)).toBe('javascript');
+  expect(await answerCard.evaluate(node => node.querySelectorAll('pre')[2]?.nextElementSibling?.nextElementSibling?.querySelector(':scope > button')?.querySelector(':scope > span')?.innerHTML)).toBe('Copy');
 
   // Reference highlight
   expect(await answerCard.evaluate(node => node.querySelectorAll('pre')[1]?.querySelector(':scope > code > mark')?.innerHTML)).toBe('no syntax');


### PR DESCRIPTION
## Problem
- Code block max-height is breaking the inline-codes. 
- If you switch between tabs while the stream is live, when you back to the tab, code blocks are not having the expand button.
- While streaming, expand code block button blinks
- Code block action icons and show more resource link icons were not visible

## Solution
- Add check to add max-height if the code is not inline.
- The expand button visibility and functionality 99% done through css now, so no flashing on expand button
- Empty cleaner was also cleaning up the icons since they didn't have content inside them, empty cleaner updated to check items with actual class names (not `<... class=""/>` but `<... class="with something"/>`)

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Checks
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
