### PR TITLE
Prevent new lines and dirty markdown in detailed list descriptions

### DIFF
--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -228,7 +228,6 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
         });
       } else if (buttonId === 'history_sheet') {
         const { update, close, changeTarget, getTargetElementId } = mynahUI.openDetailedList({
-          tabId,
           detailedList:
           {
             header: {
@@ -284,7 +283,20 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
                 {
                   id: generateUID(),
                   icon: MynahIcons.CHECK_LIST,
-                  description: '/test encrypt_input',
+                  description: `
+                  \`some very long markdown string goes
+                  \n
+                  here to see if it gets cut off properly as expected, with an ellipsis through css.some very long markdown 
+                  \n
+                  string goes here to see if it gets cut off properly as expected, with an ellipsis through css.some very 
+                  
+                  long markdown string goes here to see if it gets cut off properly as expected, with an ellipsis through css.some v
+                  
+                  ery long markdown string goes here to see if it gets cut off properly as expected, with an ellipsis through css.som
+                  
+                  e very long markdown string goes here to see if it gets cut off properly as expected, with an ellipsis through css.some
+                  
+                  very long markdown string goes here to see if it gets cut off properly as expected, with an ellipsis through css.\``,
                   actions: [
                     {
                       id: generateUID(),
@@ -533,7 +545,6 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
         });
       } else if (buttonId === 'memory_sheet') {
         const { close, update, changeTarget } = mynahUI.openDetailedList({
-          tabId,
           detailedList:
           {
             header: {

--- a/src/components/detailed-list/detailed-list-item.ts
+++ b/src/components/detailed-list/detailed-list-item.ts
@@ -67,8 +67,8 @@ export class DetailedListItemWrapper {
               ? [ {
                   type: 'div',
                   classNames: [ 'mynah-detailed-list-item-description' ],
-                  innerHTML: `<bdi>${marked.parse(this.props.listItem.description.replace(/ /g, '&nbsp;'), {
-                          breaks: true,
+                  innerHTML: `<bdi>${marked.parse(this.props.listItem.description.replace(/ /g, '&nbsp;').replace(/\n\s*\n/g, ' '), {
+                    breaks: false,
                         }) as string}</bdi>`
                 } ]
               : [])


### PR DESCRIPTION
## Problem
- Titles can break on detailed list items

## Solution
- Added `breaks:false` to avoid new lines for that specific descriptions.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
