### PR TITLE
Fixed bug where loading indicator was showing up on multiple streams

### DIFF
--- a/src/styles/components/chat/_chat-items-container.scss
+++ b/src/styles/components/chat/_chat-items-container.scss
@@ -52,7 +52,7 @@
 &.loading {
     > .mynah-chat-items-container {
         padding-bottom: var(--mynah-sizing-14);
-        > .mynah-chat-items-conversation-container {
+        > .mynah-chat-items-conversation-container:last-child {
             > .mynah-chat-item-card.mynah-chat-item-answer-stream {
                 &:last-child {
                     position: relative;


### PR DESCRIPTION
## Problem
See issue #281.

## Solution
Only apply the loading bar styling to the last conversation container.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [x] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
