### PR TITLE
Add icons with status colors for chat-item-card, header, file list

### DIFF
--- a/src/components/chat-item/chat-item-card.ts
+++ b/src/components/chat-item/chat-item-card.ts
@@ -350,7 +350,7 @@ export class ChatItemCard {
         this.cardIcon.render.remove();
         this.cardIcon = null;
       } else {
-        this.cardIcon = new Icon({ icon: this.props.chatItem.icon, subtract: this.props.chatItem.iconStatus != null, classNames: [ 'mynah-chat-item-card-icon', 'mynah-card-inner-order-10', `icon-status-${this.props.chatItem.iconStatus ?? 'none'}` ] });
+        this.cardIcon = new Icon({ icon: this.props.chatItem.icon, status: this.props.chatItem.iconForegroundStatus, subtract: this.props.chatItem.iconStatus != null, classNames: [ 'mynah-chat-item-card-icon', 'mynah-card-inner-order-10', `icon-status-${this.props.chatItem.iconStatus ?? 'none'}` ] });
         this.card?.render.insertChild('beforeend', this.cardIcon.render);
       }
     }

--- a/src/components/chat-item/chat-item-tree-file.ts
+++ b/src/components/chat-item/chat-item-tree-file.ts
@@ -86,7 +86,7 @@ export class ChatItemTreeFile {
             this.props.deleted === true ? 'mynah-chat-item-tree-view-file-item-deleted' : '',
           ],
           children: [
-            ...(this.props.details?.icon !== null ? [ new Icon({ icon: this.props.details?.icon ?? MynahIcons.FILE }).render ] : []),
+            ...(this.props.details?.icon !== null ? [ new Icon({ icon: this.props.details?.icon ?? MynahIcons.FILE, status: this.props.details?.iconForegroundStatus }).render ] : []),
             {
               type: 'span',
               classNames: [ 'mynah-chat-item-tree-view-file-item-title-text' ],

--- a/src/components/icon.ts
+++ b/src/components/icon.ts
@@ -6,6 +6,7 @@
 import { DomBuilder, ExtendedHTMLElement } from '../helper/dom';
 import { MynahUIIconImporter } from './icon/icon-importer';
 import '../styles/components/_icon.scss';
+import { Status } from '../static';
 
 export enum MynahIcons {
   Q = 'q',
@@ -82,6 +83,7 @@ export interface IconProps {
   icon: MynahIcons | MynahIconsType;
   subtract?: boolean;
   classNames?: string[];
+  status?: Status;
 }
 export class Icon {
   render: ExtendedHTMLElement;
@@ -92,6 +94,7 @@ export class Icon {
       classNames: [
         'mynah-ui-icon',
                 `mynah-ui-icon-${props.icon}${props.subtract === true ? '-subtract' : ''}`,
+                ...(props.status !== undefined ? [ `status-${props.status}` ] : []),
                 ...(props.classNames !== undefined ? props.classNames : []),
       ]
     });

--- a/src/static.ts
+++ b/src/static.ts
@@ -306,6 +306,7 @@ export interface ProgressField {
 export interface TreeNodeDetails {
   status?: Status;
   icon?: MynahIcons | MynahIconsType | null;
+  iconForegroundStatus?: Status;
   label?: string;
   changes?: {
     added?: number;
@@ -320,6 +321,7 @@ export interface ChatItemContent {
   header?: (ChatItemContent & {
     icon?: MynahIcons | MynahIconsType;
     iconStatus?: 'main' | 'primary' | 'clear' | Status;
+    iconForegroundStatus?: Status;
     status?: {
       status?: Status;
       icon?: MynahIcons | MynahIconsType;
@@ -380,6 +382,7 @@ export interface ChatItem extends ChatItemContent {
   fullWidth?: boolean;
   padding?: boolean;
   icon?: MynahIcons | MynahIconsType;
+  iconForegroundStatus?: Status;
   iconStatus?: 'main' | 'primary' | 'clear' | Status;
   hoverEffect?: boolean;
   status?: Status;

--- a/src/styles/components/_icon.scss
+++ b/src/styles/components/_icon.scss
@@ -1,3 +1,5 @@
+@import '../scss-variables';
+
 .mynah-ui-icon {
     font-style: normal;
     font-weight: normal;
@@ -13,6 +15,12 @@
 
     > span {
         display: none;
+    }
+
+    @each $status in $mynah-statuses {
+        &.status-#{$status} {
+            color: var(--mynah-color-status-#{$status});
+        }
     }
 
     // Specific colorful Q icon


### PR DESCRIPTION
## Problem

## Solution

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
