### PR TITLE
Adjusted context search algo to never include any completely partial results

### DIFF
--- a/src/helper/quick-pick-data-handler.ts
+++ b/src/helper/quick-pick-data-handler.ts
@@ -126,25 +126,7 @@ const calculateItemScore = (text: string, searchTerm: string): number => {
   if (isWordStartMatch) return 60;
   if (isContainsMatch) return 40;
 
-  return calculateScore(normalizedText, normalizedTerm);
-};
-
-const calculateScore = (text: string, term: string): number => {
-  let score = 0;
-  let termIndex = 0;
-  let consecutiveMatches = 0;
-
-  for (let i = 0; i < text.length && termIndex < term.length; i++) {
-    if (text[i] === term[termIndex]) {
-      score += 10 + consecutiveMatches;
-      consecutiveMatches++;
-      termIndex++;
-    } else {
-      consecutiveMatches = 0;
-    }
-  }
-
-  return termIndex === term.length ? score : 0;
+  return 0;
 };
 
 export const convertDetailedListGroupsToQuickActionCommandGroups = (detailedListItemGroups: DetailedListItemGroup[]): QuickActionCommandGroup[] => {


### PR DESCRIPTION
## Problem
The context selector's search algorithm was too lenient, e.g. these super partial results at the bottom should never even be returned:
![image](https://github.com/user-attachments/assets/e37900ab-f777-41b9-8793-efa4ede3ffc9)

## Solution
Return a score of `0` for all partial matches instead of building a score from partial containing matches.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
