### PR TITLE
Extended onFileClick with full fileDetails

### DIFF
--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -1055,16 +1055,23 @@ interface FileNodeAction {
   label?: string;
   disabled?: boolean;
   description?: string;
-  status?: 'info' | 'success' | 'warning' | 'error';
-  icon: MynahIcons;
+  status?: Status;
+  icon: MynahIcons | MynahIconsType;
 }
 
 interface TreeNodeDetails {
-  status?: 'info' | 'success' | 'warning' | 'error';
-  icon?: MynahIcons;
+  status?: Status;
+  icon?: MynahIcons | MynahIconsType | null;
+  iconForegroundStatus?: Status;
   label?: string;
-  description?: string; // Markdown tooltip
-  clickable?: boolean; // can it be clicked? (Default: true)
+  changes?: {
+    added?: number;
+    deleted?: number;
+    total?: number;
+  };
+  description?: string;
+  clickable?: boolean;
+  data?: Record<string, string>;
 }
 
 interface SourceLink {

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -13,6 +13,7 @@ import {
     MynahIcons,
     generateUID,
     KeyMap,
+    TreeNodeDetails,
 } from '@aws/mynah-ui';
 import { mcpButton, mynahUIDefaults, tabbarButtons } from './config';
 import { Log, LogClear } from './logger';
@@ -1132,7 +1133,7 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
         onVote: (tabId: string, messageId: string, vote: RelevancyVoteType) => {
             Log(`Message <b>${messageId}</b> is <b>${vote}d</b>.`);
         },
-        onFileClick: (tabId: string, filePath: string, deleted: boolean, messageId?: string) => {
+        onFileClick: (tabId: string, filePath: string, deleted: boolean, messageId?: string, eventId?: string, fileDetails?: TreeNodeDetails) => {
             Log(`File clicked on message ${messageId}: <b>${filePath}</b>`);
         },
         onFileActionClick: (tabId, messageId, filePath, actionName) => {

--- a/src/components/chat-item/chat-item-tree-file.ts
+++ b/src/components/chat-item/chat-item-tree-file.ts
@@ -47,6 +47,7 @@ export class ChatItemTreeFile {
               messageId: this.props.messageId,
               filePath: this.props.originalFilePath,
               deleted: this.props.deleted,
+              fileDetails: this.props.details
             });
           }
         },

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import {
   PromptAttachmentType,
   QuickActionCommand,
   DetailedList,
+  TreeNodeDetails,
 } from './static';
 import { MynahUIGlobalEvents } from './helper/events';
 import { Tabs } from './components/navigation-tabs';
@@ -274,7 +275,9 @@ export interface MynahUIProps {
     filePath: string,
     deleted: boolean,
     messageId?: string,
-    eventId?: string) => void;
+    eventId?: string,
+    fileDetails?: TreeNodeDetails
+  ) => void;
   onMessageDismiss?: (
     tabId: string,
     messageId: string,
@@ -726,7 +729,8 @@ ${(item.task ? marked.parseInline : marked.parse)(item.text, { breaks: false }) 
           data.filePath,
           data.deleted,
           data.messageId,
-          this.getUserEventId());
+          this.getUserEventId(),
+          data.fileDetails);
       }
 
       if (this.props.onOpenDiff !== undefined) {

--- a/src/static.ts
+++ b/src/static.ts
@@ -316,6 +316,7 @@ export interface TreeNodeDetails {
   };
   description?: string;
   clickable?: boolean;
+  data?: Record<string, string>;
 }
 
 export interface ChatItemContent {


### PR DESCRIPTION
## Changed
- `data?: Record<string, string>` added to `TreeNodeDetails`
- `onFileClick` extended with `fileDetails` param

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [x] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
