### PR TITLE
chore: move style loading to constructor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.30.1",
+    "version": "4.30.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.30.1",
+            "version": "4.30.2",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.30.1",
+    "version": "4.30.2",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/helper/style-loader.ts
+++ b/src/helper/style-loader.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import '../styles/styles.scss';
+
+export class StyleLoader {
+  private static instance: StyleLoader | undefined;
+  private constructor () {
+
+  }
+
+  public static getInstance (): StyleLoader {
+    if (StyleLoader.instance === undefined) {
+      StyleLoader.instance = new StyleLoader();
+    }
+
+    return StyleLoader.instance;
+  }
+
+  public destroy = (): void => {
+    StyleLoader.instance = undefined;
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,6 @@ import { FeedbackForm } from './components/feedback-form/feedback-form';
 import { MynahUITabsStore } from './helper/tabs-store';
 import { Config } from './helper/config';
 import { marked, Tokens } from 'marked';
-import './styles/styles.scss';
 import { generateUID } from './helper/guid';
 import { NoTabs } from './components/no-tabs';
 import { copyToClipboard } from './helper/chat-item';
@@ -44,6 +43,7 @@ import { Spinner } from './components/spinner/spinner';
 import { serializeHtml, serializeMarkdown } from './helper/serialize-chat';
 import { Sheet } from './components/sheet';
 import { DetailedListSheet, DetailedListSheetProps } from './components/detailed-list/detailed-list-sheet';
+import { StyleLoader } from './helper/style-loader';
 
 export { generateUID } from './helper/guid';
 export {
@@ -305,6 +305,7 @@ export class MynahUI {
   private readonly chatWrappers: Record<string, ChatWrapper> = {};
 
   constructor (props: MynahUIProps) {
+    StyleLoader.getInstance();
     // Apply global fix for marked listitem content is not getting parsed.
     marked.use({
       renderer: {


### PR DESCRIPTION
## Problem
Even though it is not expected, if there are two or more instances of MynahUI available in the consumer, because their style is being loaded even before they initialized, a conflict occurs between styles. 

## Solution
To avoid style conflicts, styles are being loaded when an instance is created in the constructor.

## Tests
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
