### PR TITLE
dogusata/move all style loading under singleton loader

### DIFF
--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -54,6 +54,7 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
   let showChatAvatars: boolean = false;
 
   const mynahUI = new MynahUI({
+    loadStyles: true,
     splashScreenInitialStatus: {
       visible: true,
       text: 'Initializing'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.30.2",
+    "version": "4.30.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.30.2",
+            "version": "4.30.3",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.30.2",
+    "version": "4.30.3",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",

--- a/src/components/background.ts
+++ b/src/components/background.ts
@@ -5,11 +5,12 @@
  */
 
 import { DomBuilder, ExtendedHTMLElement } from '../helper/dom';
-import '../styles/components/_background.scss';
+import { StyleLoader } from '../helper/style-loader';
 
 export class GradientBackground {
   render: ExtendedHTMLElement;
   constructor () {
+    StyleLoader.getInstance().load('components/_background.scss');
     this.render = DomBuilder.getInstance().build({
       type: 'div',
       classNames: [ 'mynah-ui-gradient-background' ],

--- a/src/components/button.ts
+++ b/src/components/button.ts
@@ -18,8 +18,8 @@ import { CardBody } from './card/card-body';
 import { Config } from '../helper/config';
 import { cancelEvent } from '../helper/events';
 import escapeHTML from 'escape-html';
-import '../styles/components/_button.scss';
 import unescapeHTML from 'unescape-html';
+import { StyleLoader } from '../helper/style-loader';
 
 const TOOLTIP_DELAY = 350;
 export interface ButtonProps {
@@ -59,6 +59,7 @@ class ButtonInternal extends ButtonAbstract {
   private tooltipOverlay: Overlay | null;
   private tooltipTimeout: ReturnType<typeof setTimeout>;
   constructor (props: ButtonProps) {
+    StyleLoader.getInstance().load('components/_button.scss');
     super();
     this.props = props;
     this.render = DomBuilder.getInstance().build({

--- a/src/components/card/card-body.ts
+++ b/src/components/card/card-body.ts
@@ -15,8 +15,8 @@ import unescapeHTML from 'unescape-html';
 import { Overlay, OverlayHorizontalDirection, OverlayVerticalDirection } from '../overlay';
 import { SyntaxHighlighter } from '../syntax-highlighter';
 import { generateUID } from '../../helper/guid';
-import '../../styles/components/card/_card.scss';
 import { Config } from '../../helper/config';
+import { StyleLoader } from '../../helper/style-loader';
 
 const PREVIEW_DELAY = 500;
 
@@ -59,6 +59,7 @@ export class CardBody {
   private highlightRangeTooltip: Overlay | null;
   private highlightRangeTooltipTimeout: ReturnType<typeof setTimeout>;
   constructor (props: CardBodyProps) {
+    StyleLoader.getInstance().load('components/card/_card.scss');
     this.codeBlockStartIndex = props.codeBlockStartIndex ?? 0;
     this.props = props;
     const childList = [

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -39,7 +39,7 @@ export class Card {
   private previousMousePosition!: { x: number; y: number };
   private mouseDownInfo!: { x: number; y: number; time: number };
   constructor (props: CardProps) {
-    StyleLoader.getInstance().load('/components/card/_card.scss');
+    StyleLoader.getInstance().load('components/card/_card.scss');
     this.props = props;
     this.render = DomBuilder.getInstance().build({
       type: 'div',

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { DomBuilder, DomBuilderObject, ExtendedHTMLElement } from '../../helper/dom';
+import { StyleLoader } from '../../helper/style-loader';
 import { EngagementType } from '../../static';
-import '../../styles/components/card/_card.scss';
 
 /**
  * We'll not consider it as an engagement if the total spend time is lower than below constant and won't trigger the event
@@ -39,6 +39,7 @@ export class Card {
   private previousMousePosition!: { x: number; y: number };
   private mouseDownInfo!: { x: number; y: number; time: number };
   constructor (props: CardProps) {
+    StyleLoader.getInstance().load('/components/card/_card.scss');
     this.props = props;
     this.render = DomBuilder.getInstance().build({
       type: 'div',

--- a/src/components/chat-item/chat-item-information-card.ts
+++ b/src/components/chat-item/chat-item-information-card.ts
@@ -1,8 +1,8 @@
 import { DomBuilder, ExtendedHTMLElement } from '../../helper/dom';
 import { ChatItemContent, ChatItemType } from '../../static';
 import { ChatItemCard } from './chat-item-card';
-import '../../styles/components/chat/_chat-item-card-information-card.scss';
 import { TitleDescriptionWithIcon } from '../title-description-with-icon';
+import { StyleLoader } from '../../helper/style-loader';
 
 export interface ChatItemInformationCardProps {
   tabId: string;
@@ -16,6 +16,8 @@ export class ChatItemInformationCard {
   render: ExtendedHTMLElement;
 
   constructor (props: ChatItemInformationCardProps) {
+    StyleLoader.getInstance().load('components/chat/_chat-item-card-information-card.scss');
+
     const mainContent = DomBuilder.getInstance().build({
       type: 'div',
       classNames: [ 'mynah-chat-item-information-card-main' ],

--- a/src/components/chat-item/chat-item-tabbed-card.ts
+++ b/src/components/chat-item/chat-item-tabbed-card.ts
@@ -3,9 +3,9 @@ import { ChatItemContent, ChatItemType, MynahEventNames } from '../../static';
 import { Tab, ToggleOption } from '../tabs';
 import { ChatItemCard } from './chat-item-card';
 import testIds from '../../helper/test-ids';
-import '../../styles/components/chat/_chat-item-card-tabbed-card.scss';
 import { emptyChatItemContent } from '../../helper/chat-item';
 import { MynahUIGlobalEvents } from '../../helper/events';
+import { StyleLoader } from '../../helper/style-loader';
 
 export interface ChatItemTabbedCardProps {
   tabId: string;
@@ -20,6 +20,7 @@ export class ChatItemTabbedCard {
   props: ChatItemTabbedCardProps;
 
   constructor (props: ChatItemTabbedCardProps) {
+    StyleLoader.getInstance().load('components/chat/_chat-item-card-tabbed-card.scss');
     this.props = props;
     const toggleGroup = new Tab({
       options: props.tabbedCard,

--- a/src/components/chat-item/chat-wrapper.ts
+++ b/src/components/chat-item/chat-wrapper.ts
@@ -14,11 +14,11 @@ import { ChatItemCard } from './chat-item-card';
 import { ChatPromptInput } from './chat-prompt-input';
 import { ChatPromptInputInfo } from './chat-prompt-input-info';
 import { ChatPromptInputStickyCard } from './chat-prompt-input-sticky-card';
-import '../../styles/components/chat/_chat-wrapper.scss';
 import testIds from '../../helper/test-ids';
 import { TitleDescriptionWithIcon } from '../title-description-with-icon';
 import { GradientBackground } from '../background';
 import { MoreContentIndicator } from '../more-content-indicator';
+import { StyleLoader } from '../../helper/style-loader';
 
 export const CONTAINER_GAP = 12;
 export interface ChatWrapperProps {
@@ -45,6 +45,8 @@ export class ChatWrapper {
   private allRenderedChatItems: Record<string, ChatItemCard> = {};
   render: ExtendedHTMLElement;
   constructor (props: ChatWrapperProps) {
+    StyleLoader.getInstance().load('components/chat/_chat-wrapper.scss');
+
     this.props = props;
     this.footerSpacer = DomBuilder.getInstance().build({
       type: 'div',

--- a/src/components/collapsible-content.ts
+++ b/src/components/collapsible-content.ts
@@ -6,8 +6,8 @@
 // eslint-disable @typescript-eslint/restrict-template-expressions
 import { DomBuilder, DomBuilderObject, ExtendedHTMLElement } from '../helper/dom';
 import { generateUID } from '../helper/guid';
+import { StyleLoader } from '../helper/style-loader';
 import { Icon, MynahIcons } from './icon';
-import '../styles/components/_collapsible-content.scss';
 
 interface CollapsibleContentProps {
   title: string | ExtendedHTMLElement | HTMLElement | DomBuilderObject;
@@ -23,6 +23,7 @@ export class CollapsibleContent {
   private readonly uid: string;
   private icon: ExtendedHTMLElement;
   constructor (props: CollapsibleContentProps) {
+    StyleLoader.getInstance().load('components/_collapsible-content.scss');
     this.uid = generateUID();
     this.props = {
       initialCollapsedState: true,

--- a/src/components/form-items/checkbox.ts
+++ b/src/components/form-items/checkbox.ts
@@ -6,8 +6,8 @@
 import { Config } from '../../helper/config';
 import { DomBuilder, ExtendedHTMLElement } from '../../helper/dom';
 import { cancelEvent } from '../../helper/events';
+import { StyleLoader } from '../../helper/style-loader';
 import { Icon, MynahIcons, MynahIconsType } from '../icon';
-import '../../styles/components/_form-input.scss';
 
 export interface CheckboxProps {
   type?: 'checkbox' | 'switch';
@@ -36,6 +36,7 @@ export class CheckboxInternal extends CheckboxAbstract {
   private readonly checkboxItem: ExtendedHTMLElement;
   render: ExtendedHTMLElement;
   constructor (props: CheckboxProps) {
+    StyleLoader.getInstance().load('components/_form-input.scss');
     super();
     this.checkboxItem = DomBuilder.getInstance().build({
       type: 'input',

--- a/src/components/form-items/radio-group.ts
+++ b/src/components/form-items/radio-group.ts
@@ -7,8 +7,8 @@ import { Config } from '../../helper/config';
 import { DomBuilder, DomBuilderObject, ExtendedHTMLElement } from '../../helper/dom';
 import { cancelEvent } from '../../helper/events';
 import { generateUID } from '../../helper/guid';
+import { StyleLoader } from '../../helper/style-loader';
 import { Icon, MynahIcons, MynahIconsType } from '../icon';
-import '../../styles/components/_form-input.scss';
 
 interface SelectOption {
   value: string;
@@ -41,6 +41,7 @@ export class RadioGroupInternal extends RadioGroupAbstract {
   private readonly groupName: string = generateUID();
   render: ExtendedHTMLElement;
   constructor (props: RadioGroupProps) {
+    StyleLoader.getInstance().load('components/_form-input.scss');
     super();
     this.radioGroupElement = DomBuilder.getInstance().build({
       type: 'div',

--- a/src/components/form-items/select.ts
+++ b/src/components/form-items/select.ts
@@ -5,8 +5,8 @@
 
 import { Config } from '../../helper/config';
 import { DomBuilder, DomBuilderObject, ExtendedHTMLElement } from '../../helper/dom';
+import { StyleLoader } from '../../helper/style-loader';
 import { Icon, MynahIcons, MynahIconsType } from '../icon';
-import '../../styles/components/_form-input.scss';
 
 interface SelectOption {
   value: string;
@@ -40,6 +40,7 @@ export class SelectInternal {
   private readonly selectElement: ExtendedHTMLElement;
   render: ExtendedHTMLElement;
   constructor (props: SelectProps) {
+    StyleLoader.getInstance().load('components/_form-input.scss');
     this.selectElement = DomBuilder.getInstance().build({
       type: 'select',
       testId: props.wrapperTestId,

--- a/src/components/form-items/stars.ts
+++ b/src/components/form-items/stars.ts
@@ -4,8 +4,8 @@
  */
 
 import { DomBuilder, ExtendedHTMLElement } from '../../helper/dom';
+import { StyleLoader } from '../../helper/style-loader';
 import { Icon, MynahIcons } from '../icon';
-import '../../styles/components/_form-input.scss';
 
 export type StarValues = 1 | 2 | 3 | 4 | 5;
 export interface StarsProps {
@@ -24,6 +24,7 @@ export class Stars {
   render: ExtendedHTMLElement;
 
   constructor (props: StarsProps) {
+    StyleLoader.getInstance().load('components/_form-input.scss');
     this.starsContainer = DomBuilder.getInstance().build({
       type: 'div',
       testId: props.wrapperTestId,

--- a/src/components/form-items/text-area.ts
+++ b/src/components/form-items/text-area.ts
@@ -42,7 +42,7 @@ export class TextAreaInternal extends TextAreaAbstract {
   private readyToValidate: boolean = false;
   render: ExtendedHTMLElement;
   constructor (props: TextAreaProps) {
-    StyleLoader.getInstance().load('styles/components/_form-input.scss');
+    StyleLoader.getInstance().load('components/_form-input.scss');
     super();
     this.props = props;
     this.validationErrorBlock = DomBuilder.getInstance().build({

--- a/src/components/form-items/text-area.ts
+++ b/src/components/form-items/text-area.ts
@@ -5,9 +5,9 @@
 
 import { Config } from '../../helper/config';
 import { DomBuilder, ExtendedHTMLElement } from '../../helper/dom';
+import { StyleLoader } from '../../helper/style-loader';
 import { checkTextElementValidation } from '../../helper/validator';
 import { ValidationPattern } from '../../static';
-import '../../styles/components/_form-input.scss';
 
 export interface TextAreaProps {
   classNames?: string[];
@@ -42,6 +42,7 @@ export class TextAreaInternal extends TextAreaAbstract {
   private readyToValidate: boolean = false;
   render: ExtendedHTMLElement;
   constructor (props: TextAreaProps) {
+    StyleLoader.getInstance().load('styles/components/_form-input.scss');
     super();
     this.props = props;
     this.validationErrorBlock = DomBuilder.getInstance().build({

--- a/src/components/form-items/text-input.ts
+++ b/src/components/form-items/text-input.ts
@@ -5,9 +5,9 @@
 
 import { Config } from '../../helper/config';
 import { DomBuilder, ExtendedHTMLElement } from '../../helper/dom';
+import { StyleLoader } from '../../helper/style-loader';
 import { checkTextElementValidation } from '../../helper/validator';
 import { ValidationPattern } from '../../static';
-import '../../styles/components/_form-input.scss';
 import { Icon, MynahIcons, MynahIconsType } from '../icon';
 
 export interface TextInputProps {
@@ -45,6 +45,7 @@ export class TextInputInternal extends TextInputAbstract {
   private readyToValidate: boolean = false;
   render: ExtendedHTMLElement;
   constructor (props: TextInputProps) {
+    StyleLoader.getInstance().load('components/_form-input.scss');
     super();
     this.props = props;
     this.validationErrorBlock = DomBuilder.getInstance().build({

--- a/src/components/icon.ts
+++ b/src/components/icon.ts
@@ -4,8 +4,8 @@
  */
 
 import { DomBuilder, ExtendedHTMLElement } from '../helper/dom';
+import { StyleLoader } from '../helper/style-loader';
 import { MynahUIIconImporter } from './icon/icon-importer';
-import '../styles/components/_icon.scss';
 
 export enum MynahIcons {
   Q = 'q',
@@ -86,6 +86,7 @@ export interface IconProps {
 export class Icon {
   render: ExtendedHTMLElement;
   constructor (props: IconProps) {
+    StyleLoader.getInstance().load('components/_icon.scss');
     MynahUIIconImporter.getInstance();
     this.render = DomBuilder.getInstance().build({
       type: 'i',

--- a/src/components/more-content-indicator.ts
+++ b/src/components/more-content-indicator.ts
@@ -6,8 +6,8 @@
 // eslint-disable @typescript-eslint/restrict-template-expressions
 import { DomBuilder, ExtendedHTMLElement } from '../helper/dom';
 import { Icon, MynahIcons, MynahIconsType } from './icon';
-import '../styles/components/_more-content-indicator.scss';
 import { Button } from './button';
+import { StyleLoader } from '../helper/style-loader';
 
 interface MoreContentIndicatorProps {
   icon?: MynahIcons | MynahIconsType;
@@ -22,6 +22,7 @@ export class MoreContentIndicator {
   private readonly uid: string;
   private readonly icon: ExtendedHTMLElement;
   constructor (props: MoreContentIndicatorProps) {
+    StyleLoader.getInstance().load('components/_more-content-indicator.scss');
     this.props = props;
     this.button = this.getButton();
     this.render = DomBuilder.getInstance().build({

--- a/src/components/navigation-tabs.ts
+++ b/src/components/navigation-tabs.ts
@@ -15,9 +15,9 @@ import { Icon, MynahIcons } from './icon';
 import { TabBarButtonsWrapper } from './navigation-tab-bar-buttons';
 import { Overlay, OverlayHorizontalDirection, OverlayVerticalDirection } from './overlay';
 import { Tab, ToggleOption } from './tabs';
-import '../styles/components/_nav-tabs.scss';
 import { DEFAULT_TIMEOUT } from './notification';
 import testIds from '../helper/test-ids';
+import { StyleLoader } from '../helper/style-loader';
 
 export interface TabsProps {
   onChange?: (selectedTabId: string) => void;
@@ -35,6 +35,7 @@ export class Tabs {
   private readonly props: TabsProps;
 
   constructor (props: TabsProps) {
+    StyleLoader.getInstance().load('components/_nav-tabs.scss');
     this.props = props;
     this.render = DomBuilder.getInstance().build({
       type: 'div',

--- a/src/components/no-tabs.ts
+++ b/src/components/no-tabs.ts
@@ -10,12 +10,13 @@ import { cancelEvent } from '../helper/events';
 import { MynahUITabsStore } from '../helper/tabs-store';
 import { Button } from './button';
 import { Icon, MynahIcons } from './icon';
-import '../styles/components/_no-tabs.scss';
 import testIds from '../helper/test-ids';
+import { StyleLoader } from '../helper/style-loader';
 
 export class NoTabs {
   render: ExtendedHTMLElement;
   constructor () {
+    StyleLoader.getInstance().load('components/_no-tabs.scss');
     this.render = DomBuilder.getInstance().build({
       type: 'div',
       testId: testIds.noTabs.wrapper,

--- a/src/components/notification.ts
+++ b/src/components/notification.ts
@@ -8,8 +8,8 @@ import { cancelEvent } from '../helper/events';
 import { NotificationType } from '../static';
 import { Icon, MynahIcons } from './icon';
 import { Overlay, OverlayHorizontalDirection, OverlayVerticalDirection, OVERLAY_MARGIN } from './overlay';
-import '../styles/components/_notification.scss';
 import testIds from '../helper/test-ids';
+import { StyleLoader } from '../helper/style-loader';
 
 type NotificationContentType = string | ExtendedHTMLElement | HTMLElement | DomBuilderObject;
 
@@ -31,6 +31,7 @@ export class Notification {
   private readonly props;
 
   constructor (props: NotificationProps) {
+    StyleLoader.getInstance().load('components/_notification.scss');
     this.duration = props.duration ?? DEFAULT_TIMEOUT;
     this.type = props.type ?? NotificationType.INFO;
     this.props = props;

--- a/src/components/overlay.ts
+++ b/src/components/overlay.ts
@@ -6,8 +6,8 @@
 /* eslint-disable @typescript-eslint/brace-style */
 import { DomBuilder, DomBuilderObject, ExtendedHTMLElement } from '../helper/dom';
 import { generateUID } from '../helper/guid';
+import { StyleLoader } from '../helper/style-loader';
 import { MynahPortalNames } from '../static';
-import '../styles/components/_overlay.scss';
 
 export const OVERLAY_MARGIN = 8;
 /**
@@ -84,6 +84,7 @@ export class Overlay {
   private readonly onClose;
 
   constructor (props: OverlayProps) {
+    StyleLoader.getInstance().load('components/_overlay.scss');
     const horizontalDirection = props.horizontalDirection ?? OverlayHorizontalDirection.TO_RIGHT;
     const verticalDirection = props.verticalDirection ?? OverlayVerticalDirection.START_TO_BOTTOM;
     this.onClose = props.onClose;

--- a/src/components/progress.ts
+++ b/src/components/progress.ts
@@ -5,10 +5,9 @@
 
 // eslint-disable @typescript-eslint/restrict-template-expressions
 import { DomBuilder, ExtendedHTMLElement } from '../helper/dom';
-import '../styles/components/_collapsible-content.scss';
 import { ChatItemButton, ProgressField } from '../static';
 import { ChatItemButtonsWrapper } from './chat-item/chat-item-buttons';
-import '../styles/components/_progress.scss';
+import { StyleLoader } from '../helper/style-loader';
 
 interface ProgressIndicatorProps extends ProgressField{
   testId?: string;
@@ -25,6 +24,8 @@ export class ProgressIndicator {
   private buttonsWrapper: ChatItemButtonsWrapper;
   private props: ProgressIndicatorProps;
   constructor (props: ProgressIndicatorProps) {
+    StyleLoader.getInstance().load('components/_collapsible-content.scss');
+    StyleLoader.getInstance().load('components/_progress.scss');
     this.props = props;
     this.wrapper = DomBuilder.getInstance().build({
       type: 'div',

--- a/src/components/progress.ts
+++ b/src/components/progress.ts
@@ -24,7 +24,6 @@ export class ProgressIndicator {
   private buttonsWrapper: ChatItemButtonsWrapper;
   private props: ProgressIndicatorProps;
   constructor (props: ProgressIndicatorProps) {
-    StyleLoader.getInstance().load('components/_collapsible-content.scss');
     StyleLoader.getInstance().load('components/_progress.scss');
     this.props = props;
     this.wrapper = DomBuilder.getInstance().build({

--- a/src/components/sheet.ts
+++ b/src/components/sheet.ts
@@ -6,10 +6,10 @@
 import testIds from '../helper/test-ids';
 import { DomBuilder, DomBuilderObject, ExtendedHTMLElement, MynahEventNames, MynahIcons, MynahPortalNames } from '../main';
 import { cancelEvent, MynahUIGlobalEvents } from '../helper/events';
-import '../styles/components/_sheet.scss';
 import { Button } from './button';
 import { Icon } from './icon';
 import { CardBody } from './card/card-body';
+import { StyleLoader } from '../helper/style-loader';
 
 export interface SheetProps {
   title?: string;
@@ -25,6 +25,7 @@ export class Sheet {
   onClose: () => void;
 
   constructor () {
+    StyleLoader.getInstance().load('components/_sheet.scss');
     MynahUIGlobalEvents.getInstance().addListener(MynahEventNames.OPEN_SHEET, (data: SheetProps) => {
       if (this.sheetWrapper === undefined) {
         this.sheetWrapper = DomBuilder.getInstance().createPortal(

--- a/src/components/spinner/spinner.ts
+++ b/src/components/spinner/spinner.ts
@@ -5,13 +5,14 @@
  */
 
 import { DomBuilder, ExtendedHTMLElement } from '../../helper/dom';
+import { StyleLoader } from '../../helper/style-loader';
 import LOGO_BASE from './logo-base.svg';
 import LOGO_TEXT from './logo-text.svg';
-import '../../styles/components/_spinner.scss';
 
 export class Spinner {
   render: ExtendedHTMLElement;
   constructor () {
+    StyleLoader.getInstance().load('components/_spinner.scss');
     const portal = DomBuilder.getInstance().getPortal('mynah-ui-icons') ?? DomBuilder.getInstance().createPortal('mynah-ui-icons', {
       type: 'style',
       attributes: {

--- a/src/components/syntax-highlighter.ts
+++ b/src/components/syntax-highlighter.ts
@@ -19,9 +19,9 @@ import { copyToClipboard } from '../helper/chat-item';
 import testIds from '../helper/test-ids';
 import unescapeHTML from 'unescape-html';
 import hljs from 'highlight.js';
-import '../styles/components/_syntax-highlighter.scss';
 import { mergeHTMLPlugin } from '../helper/merge-html-plugin';
 import { MoreContentIndicator } from './more-content-indicator';
+import { StyleLoader } from '../helper/style-loader';
 
 export interface SyntaxHighlighterProps {
   codeStringWithMarkup: string;
@@ -45,6 +45,7 @@ export class SyntaxHighlighter {
   render: ExtendedHTMLElement;
 
   constructor (props: SyntaxHighlighterProps) {
+    StyleLoader.getInstance().load('components/_syntax-highlighter.scss');
     this.props = props;
 
     hljs.addPlugin(mergeHTMLPlugin);

--- a/src/components/tabs.ts
+++ b/src/components/tabs.ts
@@ -6,10 +6,10 @@
 // eslint-disable @typescript-eslint/restrict-template-expressions
 import { DomBuilder, ExtendedHTMLElement } from '../helper/dom';
 import { cancelEvent } from '../helper/events';
+import { StyleLoader } from '../helper/style-loader';
 import { Button } from './button';
 import { Icon, MynahIcons, MynahIconsType } from './icon';
 import { Overlay, OverlayHorizontalDirection, OverlayVerticalDirection } from './overlay';
-import '../styles/components/_tab.scss';
 
 export interface ToggleOption {
   label?: ExtendedHTMLElement | string | HTMLElement;
@@ -155,6 +155,7 @@ export class Tab {
   private currentValue?: string | null;
 
   constructor (props: TabProps) {
+    StyleLoader.getInstance().load('components/_tab.scss');
     this.props = { direction: 'horizontal', ...props };
     this.currentValue = this.props.value;
     this.render = DomBuilder.getInstance().build({

--- a/src/components/title-description-with-icon.ts
+++ b/src/components/title-description-with-icon.ts
@@ -5,8 +5,8 @@
 
 // eslint-disable @typescript-eslint/restrict-template-expressions
 import { DomBuilder, DomBuilderObject, ExtendedHTMLElement } from '../helper/dom';
+import { StyleLoader } from '../helper/style-loader';
 import { Icon, MynahIcons, MynahIconsType } from './icon';
-import '../styles/components/_title-description-icon.scss';
 
 interface TitleDescriptionWithIconProps {
   title?: string | ExtendedHTMLElement | HTMLElement | DomBuilderObject;
@@ -19,6 +19,7 @@ export class TitleDescriptionWithIcon {
   render: ExtendedHTMLElement;
   private readonly props: TitleDescriptionWithIconProps;
   constructor (props: TitleDescriptionWithIconProps) {
+    StyleLoader.getInstance().load('components/_title-description-icon.scss');
     this.props = props;
     this.render = DomBuilder.getInstance().build({
       type: 'div',

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,3 +2,7 @@ declare module '*.svg' {
   const content: string;
   export default content;
 }
+declare module '*.scss';
+declare const require: {
+  context: (directory: string, useSubdirectories?: boolean, regExp?: RegExp) => any;
+};

--- a/src/helper/style-loader.ts
+++ b/src/helper/style-loader.ts
@@ -3,17 +3,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import '../styles/styles.scss';
-
 export class StyleLoader {
+  private readonly loadStyles: boolean;
   private static instance: StyleLoader | undefined;
-  private constructor () {
-
+  private constructor (loadStyles: boolean) {
+    this.loadStyles = loadStyles;
   }
 
-  public static getInstance (): StyleLoader {
+  public load = async (stylePath: string): Promise<void> => {
+    if (this.loadStyles) {
+      try {
+        // Create a require context for all files in the styles directory WITH subdirectories
+        const context = require.context('../styles/', true, /\.scss$/);
+
+        // Normalize the path to ensure it starts with './'
+        const normalizedPath = stylePath.startsWith('./') ? stylePath : `./${stylePath}`;
+
+        // Use the context to import the file
+        await context(normalizedPath);
+      } catch (error) {
+      }
+    }
+  };
+
+  public static getInstance (loadStyles?: boolean): StyleLoader {
     if (StyleLoader.instance === undefined) {
-      StyleLoader.instance = new StyleLoader();
+      StyleLoader.instance = new StyleLoader(loadStyles ?? true);
     }
 
     return StyleLoader.instance;

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,6 +94,7 @@ export { default as MynahUITestIds } from './helper/test-ids';
 
 export interface MynahUIProps {
   rootSelector?: string;
+  loadStyles?: boolean;
   defaults?: MynahUITabStoreTab;
   splashScreenInitialStatus?: {
     visible: boolean;
@@ -305,7 +306,8 @@ export class MynahUI {
   private readonly chatWrappers: Record<string, ChatWrapper> = {};
 
   constructor (props: MynahUIProps) {
-    StyleLoader.getInstance();
+    StyleLoader.getInstance(props.loadStyles !== false).load('styles.scss');
+
     // Apply global fix for marked listitem content is not getting parsed.
     marked.use({
       renderer: {

--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -1,4 +1,6 @@
 @import '../../scss-variables';
+@import '../chat/chat-items-bottom-animator';
+@import '../../mixins';
 .mynah-chat-item-card {
     display: inline-flex;
     flex-flow: column nowrap;
@@ -167,7 +169,7 @@
 
     &.mynah-chat-item-answer-stream {
         &.typewriter-animating {
-            @import 'chat-items-bottom-animator';
+            @include chat-items-bottom-animator();
         }
     }
 

--- a/src/styles/components/chat/_chat-items-bottom-animator.scss
+++ b/src/styles/components/chat/_chat-items-bottom-animator.scss
@@ -1,22 +1,24 @@
-&:before {
-    content: '';
-    display: none;
-    pointer-events: none;
-    position: absolute;
-    overflow: hidden;
-    border-bottom-right-radius: var(--mynah-card-radius);
-    border-bottom-left-radius: var(--mynah-card-radius-corner);
-    top: var(--mynah-border-width);
-    left: calc(-1 * var(--mynah-border-width));
-    right: calc(-1 * var(--mynah-border-width));
-    width: auto;
-    height: 100%;
-    box-sizing: border-box;
-    z-index: 10000;
-    background-image: var(--mynah-color-gradient-semi-transparent);
-    background-position: 0% top;
-    background-size: 200% calc(2.5 * var(--mynah-border-width));
-    background-repeat: repeat-x;
-    animation: none;
-    border-radius: var(--mynah-card-radius);
+@mixin chat-items-bottom-animator {
+    &:before {
+        content: '';
+        display: none;
+        pointer-events: none;
+        position: absolute;
+        overflow: hidden;
+        border-bottom-right-radius: var(--mynah-card-radius);
+        border-bottom-left-radius: var(--mynah-card-radius-corner);
+        top: var(--mynah-border-width);
+        left: calc(-1 * var(--mynah-border-width));
+        right: calc(-1 * var(--mynah-border-width));
+        width: auto;
+        height: 100%;
+        box-sizing: border-box;
+        z-index: 10000;
+        background-image: var(--mynah-color-gradient-semi-transparent);
+        background-position: 0% top;
+        background-size: 200% calc(2.5 * var(--mynah-border-width));
+        background-repeat: repeat-x;
+        animation: none;
+        border-radius: var(--mynah-card-radius);
+    }
 }

--- a/src/styles/components/chat/_chat-items-container.scss
+++ b/src/styles/components/chat/_chat-items-container.scss
@@ -48,34 +48,3 @@
         }
     }
 }
-
-&.loading {
-    > .mynah-chat-items-container {
-        padding-bottom: var(--mynah-sizing-14);
-        > .mynah-chat-items-conversation-container:last-child {
-            > .mynah-chat-item-card.mynah-chat-item-answer-stream {
-                &:last-child {
-                    position: relative;
-                    @import 'chat-items-bottom-animator';
-                    > .mynah-card {
-                        min-width: 100px;
-                        > .mynah-chat-item-card-footer {
-                            display: none;
-                        }
-                    }
-                    &.mynah-chat-item-empty {
-                        .mynah-chat-items-spinner {
-                            display: inline-flex;
-                        }
-                    }
-                    &:not(.mynah-chat-item-empty) {
-                        &:before {
-                            display: block;
-                            animation: horizontal-roll 1250ms linear infinite both;
-                        }
-                    }
-                }
-            }
-        }
-    }
-}

--- a/src/styles/components/chat/_chat-overflowing-intermediate-block.scss
+++ b/src/styles/components/chat/_chat-overflowing-intermediate-block.scss
@@ -1,16 +1,3 @@
-&.loading {
-    > .mynah-chat-overflowing-intermediate-block {
-        display: flex;
-        flex-flow: column nowrap;
-        max-height: 0;
-        overflow: visible;
-        justify-content: flex-end;
-        z-index: 10000;
-        &:not(.hidden) > .mynah-chat-stop-chat-response-button {
-            display: inline-flex;
-        }
-    }
-}
 > .mynah-chat-overflowing-intermediate-block {
     display: flex;
     flex-flow: column nowrap;

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -1,3 +1,4 @@
+@import '../../mixins';
 > .mynah-chat-prompt-wrapper {
     display: block;
     padding: var(--mynah-sizing-4);

--- a/src/styles/components/chat/_chat-wrapper.scss
+++ b/src/styles/components/chat/_chat-wrapper.scss
@@ -1,4 +1,5 @@
 @import '../../mixins';
+@import '../chat/chat-items-bottom-animator';
 .mynah-chat-prompt-overlay-buttons-container {
     display: inline-flex;
     flex-flow: column nowrap;
@@ -163,6 +164,47 @@
     @import 'chat-items-container';
     @import 'chat-overflowing-intermediate-block';
     @import 'chat-prompt-wrapper';
+    &.loading {
+        > .mynah-chat-items-container {
+            padding-bottom: var(--mynah-sizing-14);
+            > .mynah-chat-items-conversation-container:last-child {
+                > .mynah-chat-item-card.mynah-chat-item-answer-stream {
+                    &:last-child {
+                        position: relative;
+                        @include chat-items-bottom-animator();
+                        > .mynah-card {
+                            min-width: 100px;
+                            > .mynah-chat-item-card-footer {
+                                display: none;
+                            }
+                        }
+                        &.mynah-chat-item-empty {
+                            .mynah-chat-items-spinner {
+                                display: inline-flex;
+                            }
+                        }
+                        &:not(.mynah-chat-item-empty) {
+                            &:before {
+                                display: block;
+                                animation: horizontal-roll 1250ms linear infinite both;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        > .mynah-chat-overflowing-intermediate-block {
+            display: flex;
+            flex-flow: column nowrap;
+            max-height: 0;
+            overflow: visible;
+            justify-content: flex-end;
+            z-index: 10000;
+            &:not(.hidden) > .mynah-chat-stop-chat-response-button {
+                display: inline-flex;
+            }
+        }
+    }
 }
 
 .mynah-overlay > .mynah-overlay-container > .mynah-overlay-inner-container {

--- a/ui-tests/src/styles/theme.scss
+++ b/ui-tests/src/styles/theme.scss
@@ -64,7 +64,7 @@
     font-weight: 900;
     src: url('roboto-bold.ttf') format('ttf');
 }
-:root {
+html:root {
     font-size: 13px !important;
     --mynah-max-width: 100vw;
     --mynah-sizing-base: 3px;


### PR DESCRIPTION
## Problem
Styles were not being loaded through the `StyleLoader` which have the toggle to load the styles individually or skip loading them.

## Solution
Updated style loader to load individual styles dynamically. Also depending on the initialization flag.

## Tests
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
