### PR TITLE
Fix to update the tranform property in radio-group.scss file for pair-programming icon.

### DIFF
--- a/src/styles/components/form-items/_radio-group.scss
+++ b/src/styles/components/form-items/_radio-group.scss
@@ -69,9 +69,8 @@
             > .mynah-ui-icon {
                 position: relative;
                 transition: inherit;
-                transform: scale(0);
+                transform: scale(0.75);
                 transform-origin: center center;
-                color: var(--mynah-color-button);
                 z-index: var(--mynah-z-2);
             }
             &::after {


### PR DESCRIPTION

## Problem
- Pair programming icon disappears if user turn off pair programming mode.
![image](https://github.com/user-attachments/assets/63540049-bed0-465b-831e-0a6d833fe5ff)

## Solution
- Set `transform: scale(0.75)` and removed color style in `_radio-group.scss` file. 
![image](https://github.com/user-attachments/assets/a16649ed-87d9-406b-b244-d0f64c72402c)

Here is how I tested in my local VSC sandbox:
![image](https://github.com/user-attachments/assets/fea25555-f3db-4c17-a70e-33a78eef477a)


https://github.com/user-attachments/assets/6d48cb31-7271-46d6-a0e8-f45bdd1e647c


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
