### PR TITLE
fix: extra curly brace in detailed list item

### DIFF
--- a/src/components/detailed-list/detailed-list-item.ts
+++ b/src/components/detailed-list/detailed-list-item.ts
@@ -68,7 +68,7 @@ export class DetailedListItemWrapper {
               ? [ {
                   type: 'div',
                   classNames: [ 'mynah-detailed-list-item-description', this.props.descriptionTextDirection ?? 'ltr' ],
-                  innerHTML: `<bdi>${parseMarkdown(this.props.listItem.description.replace(/ /g, '&nbsp;').replace(/\n\s*\n/g, ' '), { includeLineBreaks: false, inline: true })}}</bdi>`
+                  innerHTML: `<bdi>${parseMarkdown(this.props.listItem.description.replace(/ /g, '&nbsp;').replace(/\n\s*\n/g, ' '), { includeLineBreaks: false, inline: true })}</bdi>`
                 } ]
               : [])
           ]


### PR DESCRIPTION
## Problem
Every detailed list item description ends in a `}`

## Solution
Remove extra `}` from innerHtml


Before
<img width="661" alt="Screenshot 2025-04-26 at 3 25 34 PM" src="https://github.com/user-attachments/assets/939942ed-abea-4b54-adf5-f13d1c62f0be" />

After
<img width="524" alt="Screenshot 2025-04-26 at 3 24 37 PM" src="https://github.com/user-attachments/assets/64f02359-b995-4c74-8a3e-4b7d1ca703b4" />


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
