### PR TITLE
Disabled color for no-status header status fields

### DIFF
--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -1504,6 +1504,36 @@ export const sampleHeaderTypes: ChatItem[] = [
         type: ChatItemType.ANSWER,
         fullWidth: true,
         padding: false,
+        muted: true,
+        header: {
+            icon: 'code-block',
+            status: {
+                icon: MynahIcons.CANCEL,
+                text: 'Rejected',
+            },
+            fileList: {
+                hideFileCount: true,
+                fileTreeTitle: '',
+                filePaths: ['package.json'],
+                details: {
+                    'package.json': {
+                        icon: null,
+                        label: 'Created',
+                        changes: {
+                            added: 36,
+                            deleted: 0,
+                            total: 36,
+                        },
+                    },
+                },
+            },
+        },
+    },
+
+    {
+        type: ChatItemType.ANSWER,
+        fullWidth: true,
+        padding: false,
         messageId: generateUID(),
         header: {
             icon: 'code-block',

--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -83,6 +83,10 @@
             color: var(--mynah-color-text-weak) !important;
         }
 
+        .status-default {
+            color: var(--mynah-color-text-disabled) !important;
+        }
+
         .language-diff {
             display: none !important;
         }


### PR DESCRIPTION
## Problem
Header status fields without a status color applied should get the `disabled` color instead of the `weak` color.
### Current:
![image](https://github.com/user-attachments/assets/086666f6-bed1-4fde-b802-ca2248b8bf43)

## Solution
Changed the color in case of no status:
![image](https://github.com/user-attachments/assets/764f6777-7021-400c-b12f-c21267910cab)

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
