### PR TITLE
fix: apply background to selection list items

### DIFF
--- a/src/styles/components/_form-input.scss
+++ b/src/styles/components/_form-input.scss
@@ -75,6 +75,9 @@
                 white-space: nowrap;
                 overflow: hidden;
             }
+            option {
+                background-color: var(--mynah-card-bg);
+            }
             option.empty-option {
                 font-style: italic;
                 opacity: 0.5;


### PR DESCRIPTION
## Problem

When open, the selection list does not have a themed background defined. It shows up in dark themes as white, and you may not see the item text.

## Solution

Apply a background to selection items.

## Tests

Verified using the sample app workbench.

![image](https://github.com/user-attachments/assets/8452c3e6-5b41-4d84-836a-6a840eb45435)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
