### PR TITLE
Middle click (and only middle click) closes tabs

### DIFF
--- a/src/components/tabs.ts
+++ b/src/components/tabs.ts
@@ -107,11 +107,12 @@ class TabItem {
             dblclick: (e) => {
               cancelEvent(e);
             },
-            auxclick: () => {
-              if (this.props.onRemove !== undefined && this.props.pinned !== true) {
+            auxclick: (e) => {
+              // only close on middle click
+              if (e.button === 1 && this.props.onRemove !== undefined && this.props.pinned !== true) {
                 this.props.onRemove(this.props.value, this.render);
               }
-            }
+            },
           },
           children: [
             this.props.icon != null ? new Icon({ icon: props.icon as MynahIcons }).render : '',


### PR DESCRIPTION
## Problem
In Chromium-based envs (including JetBrains IDEs), _any_ non-primary click on a tab closes the tab. This includes right-click, middle click, and the forward/backward buttons on five-button mice

## Solution
Only close tabs when clicked with the middle click button (I'm assuming this was the original intent)

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [x] I have tested this change on JetBrains
- [x] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
