### PR TITLE
fix: autofocus shifts screen after command selection with click

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -588,6 +588,9 @@ export class ChatPromptInput {
     if (quickActionCommand.placeholder !== undefined) {
       this.promptTextInputCommand.setCommand(this.selectedCommand);
       this.promptTextInput.updateTextInputPlaceholder(quickActionCommand.placeholder);
+      if (Config.getInstance().config.autoFocus) {
+        this.promptTextInput.focus();
+      }
     } else if (method === 'enter' || method === 'click') {
       this.sendPrompt();
     } else {
@@ -597,9 +600,6 @@ export class ChatPromptInput {
       this.render.addClass('awaits-confirmation');
     }
     this.quickPick.close();
-    if (Config.getInstance().config.autoFocus) {
-      this.promptTextInput.focus();
-    }
   };
 
   private readonly handleContextCommandSelection = (dirtyContextCommand: QuickActionCommand): void => {


### PR DESCRIPTION
## Problem
- If you have a command, which doesn't have a placeholder _(which means that you can directly select it without additonal prompt)_ 
- 
## Solution

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
