### PR TITLE
Add padding to dropdowns

### DIFF
--- a/src/styles/components/_form-input.scss
+++ b/src/styles/components/_form-input.scss
@@ -86,7 +86,6 @@
 
             -webkit-appearance: none;
             appearance: none;
-            padding: 0;
             border: none;
             text-overflow: clip;
             outline: none;
@@ -124,6 +123,10 @@
             &.validation-error {
                 border-color: var(--mynah-color-status-error);
             }
+        }
+
+        select.mynah-form-input {
+            padding: 0px var(--mynah-sizing-2);
         }
 
         > .select-auto-width-sizer {
@@ -165,10 +168,9 @@
         }
         > .mynah-form-input-icon {
             color: var(--mynah-color-text-weak);
-            margin-right: var(--mynah-sizing-2);
         }
         > .mynah-select-handle {
-            position: absolute;
+            position: relative;
             color: var(--mynah-color-text-weak);
             pointer-events: none;
             transform: translateX(-25%);


### PR DESCRIPTION
## Problem

Dropdowns, when opened in a Chromium-based browser (most of the IDEs) don't have padding.
![image](https://github.com/user-attachments/assets/36446fd7-2713-4fde-ae72-93ea26fce44a)

![image](https://github.com/user-attachments/assets/580f6fdf-253c-4d3d-a8e6-08decb69f600)


## Solution

Add padding, and adjust as many other elements to reduce the impact. Notably: this doubles the space between the Agentic selector and the dropdown because I'm not removing the `gap`; I'm assuming this will be good practice if we add more to this container. Happy to discuss if this looks bad (I'd probably remove or shrink the gap). Note that the padding in this case is non-negotiable since the padding on the select also drives padding on the options.

![image](https://github.com/user-attachments/assets/3a38c603-0608-4a1e-b1d3-fd17e61ed274)

![image](https://github.com/user-attachments/assets/88397c0e-8248-48e9-9632-3a965569ac7e)


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
