### PR TITLE
feat: allow mandatory form item without asterisk

### DIFF
--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -1073,6 +1073,7 @@ export interface ValidationPattern {
 interface BaseFormItem {
   id: string;
   mandatory?: boolean;
+  hideMandatoryIcon?: boolean;
   title?: string;
   placeholder?: string;
   value?: string;
@@ -1130,6 +1131,7 @@ export interface ListFormItem {
   type: 'list';
   id: string;
   mandatory?: boolean;
+  hideMandatoryIcon?: boolean;
   title?: string;
   description?: string;
   tooltip?: string;
@@ -2696,6 +2698,7 @@ interface ChatItemFormItem {
   id: string; // id is mandatory to understand to get the specific values for each form item when a button is clicked
   type: 'select' | 'textarea' | 'textinput' | 'numericinput' | 'stars' | 'radiogroup' | 'toggle' | 'checkbox' | 'switch' ; // type (see below for each of them)
   mandatory?: boolean; // If it is set to true, buttons in the same card with waitMandatoryFormItems set to true will wait them to be filled
+  hideMandatoryIcon?: boolean; // If it is set to true, it won't render an asterisk icon next to the form label
   title?: string; // Label of the input
   autoFocus: boolean; // focus to the input when it is created, default=> false. (Only for textual form items)
   description?: string; // The description, showing under the input field itself

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -267,7 +267,7 @@ export const mynahUIDefaults: Partial<MynahUITabStoreTab> = {
                 border: false,
                 autoWidth: true,
                 id: 'model-select',
-                placeholder: 'Auto',
+                mandatory: true,
                 options: [
                     {
                         label: 'Fast',

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -268,6 +268,7 @@ export const mynahUIDefaults: Partial<MynahUITabStoreTab> = {
                 autoWidth: true,
                 id: 'model-select',
                 mandatory: true,
+                hideMandatoryIcon: true,
                 options: [
                     {
                         label: 'Fast',

--- a/src/components/__test__/chat-item/chat-item-form-items.spec.ts
+++ b/src/components/__test__/chat-item/chat-item-form-items.spec.ts
@@ -1,0 +1,83 @@
+import { ChatItem, ChatItemType } from '../../../static';
+import { ChatItemFormItemsWrapper } from '../../chat-item/chat-item-form-items';
+import { MynahIcons } from '../../icon';
+
+describe('chat-item-form-items', () => {
+  // Helper function to create a mock chat item with form items
+  const createMockChatItem = (formItems: any[]): Partial<ChatItem> => ({
+    type: ChatItemType.ANSWER,
+    messageId: 'testMessageId',
+    formItems
+  });
+
+  it('should render mandatory form item with title correctly', () => {
+    const mockChatItem = createMockChatItem([
+      {
+        id: 'test-item',
+        type: 'textinput',
+        title: 'Test Title',
+        mandatory: true
+      }
+    ]);
+
+    const formItemsWrapper = new ChatItemFormItemsWrapper({
+      tabId: 'tab-1',
+      chatItem: mockChatItem
+    });
+
+    // Find the mandatory title element using data-testid attribute
+    const titleElement = formItemsWrapper.render.querySelector('.mynah-ui-form-item-mandatory-title');
+    expect(titleElement).not.toBeNull();
+
+    // Check that it contains the asterisk icon
+    const asteriskIcon = titleElement?.querySelector('i.mynah-ui-icon');
+    expect(asteriskIcon).not.toBeNull();
+    expect(asteriskIcon?.classList.contains(`mynah-ui-icon-${MynahIcons.ASTERISK}`)).toBeTruthy();
+
+    // Check that the title text is present
+    expect(titleElement?.textContent?.includes('Test Title')).toBeTruthy();
+  });
+
+  it('should handle mandatory form item with undefined title correctly', () => {
+    const mockChatItem = createMockChatItem([
+      {
+        id: 'test-item',
+        type: 'textinput',
+        mandatory: true,
+        title: undefined
+      }
+    ]);
+
+    const formItemsWrapper = new ChatItemFormItemsWrapper({
+      tabId: 'tab-1',
+      chatItem: mockChatItem
+    });
+
+    // There should be no mandatory title element since title is undefined
+    const titleElement = formItemsWrapper.render.querySelector('.mynah-ui-form-item-mandatory-title');
+    expect(titleElement).toBeNull();
+  });
+
+  it('should set default value for mandatory select items', () => {
+    const mockChatItem = createMockChatItem([
+      {
+        id: 'model-select',
+        type: 'select',
+        mandatory: true,
+        options: [
+          { label: 'Option 1', value: 'option1' },
+          { label: 'Option 2', value: 'option2' }
+        ]
+      }
+    ]);
+
+    const formItemsWrapper = new ChatItemFormItemsWrapper({
+      tabId: 'tab-1',
+      chatItem: mockChatItem
+    });
+
+    // The form item should have its value set to the first option
+    const formData = formItemsWrapper.getAllValues();
+    expect(formData['model-select']).toBe('option1');
+  });
+});

--- a/src/components/__test__/chat-item/chat-item-form-items.spec.ts
+++ b/src/components/__test__/chat-item/chat-item-form-items.spec.ts
@@ -38,13 +38,14 @@ describe('chat-item-form-items', () => {
     expect(titleElement?.textContent?.includes('Test Title')).toBeTruthy();
   });
 
-  it('should handle mandatory form item with undefined title correctly', () => {
+  it('should hide mandatory icon when hideMandatoryIcon is true', () => {
     const mockChatItem = createMockChatItem([
       {
         id: 'test-item',
         type: 'textinput',
+        title: 'Test Title',
         mandatory: true,
-        title: undefined
+        hideMandatoryIcon: true
       }
     ]);
 
@@ -53,9 +54,34 @@ describe('chat-item-form-items', () => {
       chatItem: mockChatItem
     });
 
-    // There should be no mandatory title element since title is undefined
+    // There should be no mandatory title element with asterisk since hideMandatoryIcon is true
     const titleElement = formItemsWrapper.render.querySelector('.mynah-ui-form-item-mandatory-title');
     expect(titleElement).toBeNull();
+  });
+
+  it('should show mandatory icon when hideMandatoryIcon is false', () => {
+    const mockChatItem = createMockChatItem([
+      {
+        id: 'test-item',
+        type: 'textinput',
+        title: 'Test Title',
+        mandatory: true,
+        hideMandatoryIcon: false
+      }
+    ]);
+
+    const formItemsWrapper = new ChatItemFormItemsWrapper({
+      tabId: 'tab-1',
+      chatItem: mockChatItem
+    });
+
+    // The mandatory title element should be present with asterisk
+    const titleElement = formItemsWrapper.render.querySelector('.mynah-ui-form-item-mandatory-title');
+    expect(titleElement).not.toBeNull();
+
+    // Check that it contains the asterisk icon
+    const asteriskIcon = titleElement?.querySelector('i.mynah-ui-icon');
+    expect(asteriskIcon).not.toBeNull();
   });
 
   it('should set default value for mandatory select items', () => {

--- a/src/components/chat-item/chat-item-form-items.ts
+++ b/src/components/chat-item/chat-item-form-items.ts
@@ -49,17 +49,19 @@ export class ChatItemFormItemsWrapper {
       classNames: [ 'mynah-chat-item-form-items-container', ...(this.props.classNames ?? []) ],
       children: this.props.chatItem.formItems?.map(chatItemOption => {
         let chatOption: Select | RadioGroup | TextArea | Stars | TextInput | Checkbox | FormItemList | undefined;
-        let label: ExtendedHTMLElement | string = `${chatItemOption.mandatory === true ? '* ' : ''}${chatItemOption.title ?? ''}`;
+        let label: ExtendedHTMLElement | string = `${chatItemOption.mandatory === true && chatItemOption.title !== undefined ? '* ' : ''}${chatItemOption.title ?? ''}`;
         if (chatItemOption.mandatory === true) {
-          label = DomBuilder.getInstance().build({
-            type: 'div',
-            testId: testIds.chatItem.chatItemForm.title,
-            classNames: [ 'mynah-ui-form-item-mandatory-title' ],
-            children: [
-              new Icon({ icon: MynahIcons.ASTERISK }).render,
-              chatItemOption.title ?? '',
-            ]
-          });
+          if (chatItemOption.title !== undefined) {
+            label = DomBuilder.getInstance().build({
+              type: 'div',
+              testId: testIds.chatItem.chatItemForm.title,
+              classNames: [ 'mynah-ui-form-item-mandatory-title' ],
+              children: [
+                new Icon({ icon: MynahIcons.ASTERISK }).render,
+                chatItemOption.title,
+              ]
+            });
+          }
           // Since the field is mandatory, default the selected value to the first option
           if (chatItemOption.type === 'select' && chatItemOption.value === undefined) {
             chatItemOption.value = chatItemOption.options?.[0]?.value;

--- a/src/components/chat-item/chat-item-form-items.ts
+++ b/src/components/chat-item/chat-item-form-items.ts
@@ -49,16 +49,16 @@ export class ChatItemFormItemsWrapper {
       classNames: [ 'mynah-chat-item-form-items-container', ...(this.props.classNames ?? []) ],
       children: this.props.chatItem.formItems?.map(chatItemOption => {
         let chatOption: Select | RadioGroup | TextArea | Stars | TextInput | Checkbox | FormItemList | undefined;
-        let label: ExtendedHTMLElement | string = `${chatItemOption.mandatory === true && chatItemOption.title !== undefined ? '* ' : ''}${chatItemOption.title ?? ''}`;
+        let label: ExtendedHTMLElement | string = `${chatItemOption.mandatory === true && chatItemOption.hideMandatoryIcon !== true ? '* ' : ''}${chatItemOption.title ?? ''}`;
         if (chatItemOption.mandatory === true) {
-          if (chatItemOption.title !== undefined) {
+          if (chatItemOption.hideMandatoryIcon !== true) {
             label = DomBuilder.getInstance().build({
               type: 'div',
               testId: testIds.chatItem.chatItemForm.title,
               classNames: [ 'mynah-ui-form-item-mandatory-title' ],
               children: [
                 new Icon({ icon: MynahIcons.ASTERISK }).render,
-                chatItemOption.title,
+                chatItemOption.title ?? '',
               ]
             });
           }

--- a/src/static.ts
+++ b/src/static.ts
@@ -440,6 +440,7 @@ export interface ValidationPattern {
 interface BaseFormItem {
   id: string;
   mandatory?: boolean;
+  hideMandatoryIcon?: boolean;
   title?: string;
   placeholder?: string;
   value?: string;
@@ -501,6 +502,7 @@ export interface ListFormItem {
   type: 'list';
   id: string;
   mandatory?: boolean;
+  hideMandatoryIcon?: boolean;
   title?: string;
   description?: string;
   tooltip?: string;


### PR DESCRIPTION
## Problem

When using the dropdown select component, you can use `mandatory: true` to hide the placeholder/"Please select" option from the dropdown. However doing so will also render an asterisk icon above it. We want to be able to hide the asterisk for certain cases, ie in prompt options for model selection.

<img width="227" alt="image" src="https://github.com/user-attachments/assets/efea8401-1c6c-4271-9fcc-3d4da661aad8" />


## Solution

Only render the asterisk if mandatory is true **and** ~~the form item title is not undefined~~ new flag `hideMandatoryIcon` is not set to true 

<img width="215" alt="image" src="https://github.com/user-attachments/assets/949e845d-414c-4925-b9ff-20a1bdcf9b00" />
<img width="541" alt="image" src="https://github.com/user-attachments/assets/32bd8a88-460d-4e0c-a710-9b407cc08d25" />


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [x] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
