### PR TITLE
feat: remove the scroll bar for detailed list

### DIFF
--- a/src/styles/components/_sheet.scss
+++ b/src/styles/components/_sheet.scss
@@ -144,7 +144,7 @@
         }
 
         > .mynah-detailed-list {
-            overflow-y: scroll;
+            overflow-y: auto;
             overflow-x: hidden;
         }
 


### PR DESCRIPTION
## Problem
there were multi scroll bar on windows detailedList. (mcp server list and chat history)
## Solution
change the overflow-y for detailedList from scroll to auto
<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
