### PR TITLE
feat: add hover effect for clickable detailed list items

### DIFF
--- a/src/styles/components/_detailed-list.scss
+++ b/src/styles/components/_detailed-list.scss
@@ -140,6 +140,7 @@
                         }
                     }
                     &:hover:not([disabled='true']):not([selectable='false']),
+                    &:hover:not([disabled='true'])[clickable='true'],
                     &.target-command:not([disabled='true']):not([selectable='false']) {
                         background-color: var(--mynah-color-button);
                         &,


### PR DESCRIPTION
## Problem
- when `clickable='true'`, there is no highlighting over the rows

## Solution
- for `clickable='true'`, user sees highlighting over rows when hovered over

https://github.com/user-attachments/assets/edf46682-1483-486b-881b-76bcc73e97dd





<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
