### PR TITLE
fix: updating some css styles to sticky card view

### DIFF
--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -1521,6 +1521,11 @@ here to see if it gets cut off properly as expected, with an ellipsis through cs
                     mynahUI.updateStore(tabId, {
                         promptInputStickyCard: {
                             messageId: 'sticky-card',
+                            header: {
+                                icon: 'code-block',
+                                iconStatus: 'info',
+                                body: '### Terms and Conditions',
+                            },
                             body: `Our [Terms and Conditions](#) are updated. Please review and read it. To accept please hit the **Acknowledge** button.`,
                             buttons: [
                                 {

--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -625,6 +625,10 @@ export const defaultFollowUps: ChatItem = {
                 command: Commands.BUTTONS,
             },
             {
+                pillText: 'Sticky card',
+                command: Commands.SHOW_STICKY_CARD,
+            },
+            {
                 pillText: 'Some auto reply',
                 prompt: 'Some random auto reply here.',
             },

--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -391,7 +391,7 @@
 > .mynah-chat-prompt-input-sticky-card {
     &:not(:empty) {
         padding: var(--mynah-chat-wrapper-spacing);
-        padding-bottom: 0;
+        background-color: var(--mynah-card-bg);
     }
 
     > .mynah-chat-item-card {


### PR DESCRIPTION
## Problem
- No background color for sticky card view.
## Solution
- Adding background color for sticky card view.
- Removing the `padding-bottom: 0`, so that it adds some padding to the sticky card.
- Adding example data to use the sticky card in the [Live Mynah](https://aws.github.io/mynah-ui/).

## Media:
![image](https://github.com/user-attachments/assets/cc3a712a-fc6b-43fb-91fa-dff52e3c053d)

![image](https://github.com/user-attachments/assets/8a16cc1f-cc58-497b-a735-13c526f3b4d6)

![image](https://github.com/user-attachments/assets/6b886503-c264-4502-b7e7-096ff526d042)

![image](https://github.com/user-attachments/assets/26eed34d-5d06-4e69-a7dc-e251ff420a9e)

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
