### PR TITLE
fix: add boarder and padding to sticky card

### DIFF
--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -391,7 +391,13 @@
 > .mynah-chat-prompt-input-sticky-card {
     &:not(:empty) {
         padding: var(--mynah-chat-wrapper-spacing);
-        padding-bottom: 0;
+        background-color: var(--mynah-card-bg);
+        border: var(--mynah-border-width) solid var(--mynah-color-border-default);
+        border-radius: var(--mynah-input-radius);
+        box-sizing: border-box;
+        margin: var(--mynah-chat-wrapper-spacing);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        width: calc(100% - 2 * var(--mynah-chat-wrapper-spacing));
     }
 
     > .mynah-chat-item-card {
@@ -399,6 +405,8 @@
         width: 100%;
         > .mynah-card {
             border-bottom-left-radius: 0 !important;
+            border: none;
+            box-shadow: none;
         }
     }
 }


### PR DESCRIPTION
## Problem
The sticky card does not have boarder and padding 
## Solution
Change the css format to add boarder and padding for the sticky card. 
![image](https://github.com/user-attachments/assets/8b2b9b29-14ee-4c73-b86b-4149c5a26175)

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
