### PR TITLE
Use different ref for checkout to allow forked pull requests

### DIFF
--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -11,7 +11,7 @@ jobs:
           - name: Checkout Code
             uses: actions/checkout@v4
             with:
-              ref: ${{ github.head_ref }}
+              ref: ${{ github.event.pull_request.head.sha }}
               fetch-depth: 0
 
           # Set up Docker Buildx


### PR DESCRIPTION
## Problem
The `e2e-linux` testing CI script fails for PRs from forked branches as the `ref: ${{ github.head_ref }}` is unavailable here.

## Solution
Replace this ref by `ref: ${{ github.event.pull_request.head.sha }}`.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests (NA)
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
