### PR TITLE
Specify repository in e2e CI runner

### DIFF
--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -11,8 +11,8 @@ jobs:
           - name: Checkout Code
             uses: actions/checkout@v4
             with:
-              ref: ${{ github.event.pull_request.head.sha }}
-              fetch-depth: 0
+              ref: ${{ github.event.pull_request.head.ref }}
+              repository: ${{ github.event.pull_request.head.repo.full_name }}
 
           # Set up Docker Buildx
           - name: Set up Docker Buildx


### PR DESCRIPTION
## Problem
The E2E script fails for PRs from forked branches.

## Solution
Specify repository for the checkout.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
