### PR TITLE
Added coverage generation for jest unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ package-lock.json
 .vscode
 __results__/
 e2e-results/
+coverage/

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "tests:e2e:chromium": "npm run docker:clean && npm run docker:build && npm run docker:run:chromium",
         "tests:e2e:webkit": "npm run docker:clean && npm run docker:build && npm run docker:run:webkit",
         "tests:e2e:trace": "cd ./ui-tests && npm run trace",
-        "tests:unit": "jest",
+        "tests:unit": "jest --collect-coverage",
         "api-docs": "npx typedoc src/main.ts --out ./api-docs",
         "api-doc-deploy": "npx typedoc src/main.ts --out ./example/dist/api-doc",
         "postinstall": "node postinstall.js",


### PR DESCRIPTION
## Problem
There was no coverage generation for the unit tests.

## Solution
Added the `--collect-coverage` flag for the unit tests script to ensure a `/coverage` folder is generated and the coverage is reported in CLI.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## ~Tests (NA)~
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
