### PR TITLE
Don't use Docker cache on forked PRs

### DIFF
--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -20,14 +20,16 @@ jobs:
             
           # Login to GitHub Container Registry
           - name: Login to GitHub Container Registry
+            if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
             uses: docker/login-action@v3
             with:
               registry: ghcr.io
               username: ${{ github.actor }}
               password: ${{ secrets.GITHUB_TOKEN }}
-            
-          # Build Docker image with caching
-          - name: Build E2E tests Docker Image
+
+          # Build Docker image with caching (for non-fork PRs)
+          - name: Build E2E tests Docker Image (with cache)
+            if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
             uses: docker/build-push-action@v5
             with:
               context: .
@@ -36,6 +38,16 @@ jobs:
               tags: mynah-ui-e2e:latest
               cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/mynah-ui-e2e:buildcache
               cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/mynah-ui-e2e:buildcache,mode=max
+
+          # Build Docker image without caching (for fork PRs)
+          - name: Build E2E tests Docker Image (no cache)
+            if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+            uses: docker/build-push-action@v5
+            with:
+              context: .
+              push: false
+              load: true
+              tags: mynah-ui-e2e:latest
 
           # Run the Docker container
           - name: Run E2E tests Docker Container


### PR DESCRIPTION
## Problem
E2E testing workflow fails for PRs from forked repos because they can't access the GitHub Container Registry.

## Solution
Skip Docker caching on PRs from forked repos.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## ~Tests (NA)~
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
