### PR TITLE
fix: crossIcon position

### DIFF
--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -1521,6 +1521,7 @@ here to see if it gets cut off properly as expected, with an ellipsis through cs
                     mynahUI.updateStore(tabId, {
                         promptInputStickyCard: {
                             messageId: 'sticky-card',
+                            canBeDismissed: true,
                             header: {
                                 icon: 'code-block',
                                 iconStatus: 'info',

--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -360,6 +360,7 @@
             }
             > .mynah-button {
                 flex-shrink: 0;
+                margin-left: auto;
             }
             & + .mynah-chat-item-card-header {
                 @include full-width-header();


### PR DESCRIPTION
## Problem
We had a wrong dismiss icon on the top left, which do not meet UX design
![Screenshot 2025-06-13 at 5 14 55 PM](https://github.com/user-attachments/assets/1825a917-8565-4b7a-af49-21a39c7cc0c1)

## Solution
Move the dismiss icon to the right
![Screenshot 2025-06-13 at 6 35 07 PM](https://github.com/user-attachments/assets/fbb0d8bc-4a36-4dbc-8d87-acfca87ddbf0)


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
