### PR TITLE
fix: status should be dimmed if muted is true

### DIFF
--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -1596,6 +1596,38 @@ export const sampleHeaderTypes: ChatItem[] = [
         type: ChatItemType.ANSWER,
         fullWidth: true,
         padding: false,
+        muted: true,
+        header: {
+            icon: 'code-block',
+            status: {
+                icon: MynahIcons.ERROR,
+                text: 'Error',
+                status: 'error',
+                description: 'There was an error while creating the file.',
+            },
+            fileList: {
+                hideFileCount: true,
+                fileTreeTitle: '',
+                filePaths: ['package.json'],
+                details: {
+                    'package.json': {
+                        icon: null,
+                        label: 'Created',
+                        changes: {
+                            added: 36,
+                            deleted: 0,
+                            total: 36,
+                        },
+                    },
+                },
+            },
+        },
+    },
+
+    {
+        type: ChatItemType.ANSWER,
+        fullWidth: true,
+        padding: false,
         messageId: generateUID(),
         header: {
             icon: 'code-block',

--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -101,7 +101,7 @@
         .mynah-chat-item-card-header-status * {
             filter: none !important;
             -webkit-filter: none !important;
-            opacity: 100%;
+            opacity: 60%;
         }
 
         .mynah-button {


### PR DESCRIPTION
## Problem
Header status should be dimmed if the chat item has `muted: true`

## Solution
Lower the opacity

Before: 
<img width="550" alt="image" src="https://github.com/user-attachments/assets/8dee764b-268b-4b8f-a2f3-33d8872c0684" />
After:
<img width="550" alt="image" src="https://github.com/user-attachments/assets/43fe5ac3-5deb-41a6-b81b-8f2efc0031b9" />


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
