### PR TITLE
fix: chat prompt select looks disabled

### DIFF
--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -254,7 +254,7 @@
                                     > select {
                                         width: auto;
                                         min-width: auto;
-                                        color: var(--mynah-color-text-weak);
+                                        color: var(--mynah-color-text-default);
                                         font-size: var(--mynah-font-size-small);
                                         & + i {
                                             font-size: var(--mynah-font-size-xsmall);


### PR DESCRIPTION
## Problem

Chat input prompt looks like its in a disabled state when its not

## Solution

Before:
<img width="458" alt="image" src="https://github.com/user-attachments/assets/ecfecc10-5bc3-4e9b-9f47-93be372b16ed" />


After:
<img width="462" alt="image" src="https://github.com/user-attachments/assets/830953c6-5b71-452a-babc-2efcb9da076f" />


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
