### PR TITLE
allow both capitalized and all lowercases command name used for image…

### DIFF
--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -1079,7 +1079,7 @@ here to see if it gets cut off properly as expected, with an ellipsis through cs
         },
 
         onContextSelected(contextItem, tabId) {
-            if (contextItem.command === 'image') {
+            if (contextItem.command.toLowerCase() === 'image') {
                 const fileInput = document.createElement('input');
                 fileInput.type = 'file';
                 fileInput.accept = 'image/*';

--- a/src/components/chat-item/chat-wrapper.ts
+++ b/src/components/chat-item/chat-wrapper.ts
@@ -506,7 +506,7 @@ export class ChatWrapper {
   private hasImageContextCommand (): boolean {
     const contextCommands = MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).getValue('contextCommands') as QuickActionCommandGroup[] | undefined;
     return !((contextCommands?.some(group =>
-      group.commands.some((cmd: QuickActionCommand) => cmd.command === 'image')
+      group.commands.some((cmd: QuickActionCommand) => cmd.command.toLowerCase() === 'image')
     )) === false);
   }
 

--- a/src/components/chat-item/prompt-input/prompt-text-input.ts
+++ b/src/components/chat-item/prompt-input/prompt-text-input.ts
@@ -78,7 +78,7 @@ export class PromptTextInput {
           // Check if image command exists in context commands to make the feature consistent
           const contextCommands = MynahUITabsStore.getInstance().getTabDataStore(this.props.tabId).getValue('contextCommands') as QuickActionCommandGroup[] | undefined;
           const hasImageCommand = contextCommands?.some(group =>
-            group.commands.some(cmd => cmd.command === 'image')
+            group.commands.some(cmd => cmd.command.toLowerCase() === 'image')
           );
 
           if (hasImageCommand ?? false) {


### PR DESCRIPTION
… context

## Problem
For the context provided by language-server, all commands are capitalized, 
<img width="331" alt="Screenshot 2025-06-23 at 3 32 57 PM" src="https://github.com/user-attachments/assets/c8c02e35-095c-41f2-b75a-1a7de28912c5" />

and in the context provided in `example`, commands name are all lower cases. 
<img width="509" alt="Screenshot 2025-06-23 at 3 33 34 PM" src="https://github.com/user-attachments/assets/5e28c2b5-81d5-4b07-ab27-d16da58e18fd" />





## Solution
To make the components able to handle image context provided by both cases(from example's config & language-server context provider), add logic of to lower cases the command name. 
<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
