### PR TITLE
fix: Dropdowns not closing when selected option is reselected

### DIFF
--- a/src/styles/components/_form-input.scss
+++ b/src/styles/components/_form-input.scss
@@ -127,7 +127,6 @@
 
         select.mynah-form-input {
             padding: 0px var(--mynah-sizing-2);
-            -webkit-appearance: none;
             appearance: menulist;
         }
 

--- a/src/styles/components/_form-input.scss
+++ b/src/styles/components/_form-input.scss
@@ -127,6 +127,8 @@
 
         select.mynah-form-input {
             padding: 0px var(--mynah-sizing-2);
+            -webkit-appearance: menulist;
+            appearance: menulist;
         }
 
         > .select-auto-width-sizer {
@@ -174,6 +176,7 @@
             color: var(--mynah-color-text-weak);
             pointer-events: none;
             transform: translateX(-25%);
+            visibility: hidden;
         }
         & ~ .mynah-form-input-validation-error-block {
             display: flex;

--- a/src/styles/components/_form-input.scss
+++ b/src/styles/components/_form-input.scss
@@ -127,6 +127,7 @@
 
         select.mynah-form-input {
             padding: 0px var(--mynah-sizing-2);
+            -webkit-appearance: none;
             appearance: menulist;
         }
 
@@ -176,6 +177,9 @@
             pointer-events: none;
             transform: translateX(-25%);
             visibility: hidden;
+            @supports (-webkit-appearance: none) and (not (appearance: menulist)) {
+                visibility: visible;
+            }
         }
         & ~ .mynah-form-input-validation-error-block {
             display: flex;

--- a/src/styles/components/_form-input.scss
+++ b/src/styles/components/_form-input.scss
@@ -127,7 +127,7 @@
 
         select.mynah-form-input {
             padding: 0px var(--mynah-sizing-2);
-            -webkit-appearance: menulist;
+            -webkit-appearance: none;
             appearance: menulist;
         }
 


### PR DESCRIPTION
## Problem
Dropdowns were not closing when a selected option was reselected. Customers had to click multiple times outside the chat to close the dropdowns.

## Solution
Setting menulist properties ensures that select dropdowns maintain their native operating system behavior.
This was causing a side effect of custom arrows and native arrows being rendered twice. So the custom arrows on select elements have been hidden. Removing them entirely results in text being truncated in the dropdown appearance.

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ x ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
