### PR TITLE
fix: only show commandActionHeader when it is not null

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -734,11 +734,18 @@ export class ChatPromptInput {
       headerComponent = newHeaderComponent;
     });
 
+    // Only show header if it has meaningful content
+    const hasHeaderContent = headerInfo != null && (
+      (headerInfo.title != null && headerInfo.title.trim() !== '') ||
+      (headerInfo.description != null && headerInfo.description.trim() !== '') ||
+      headerInfo.icon != null
+    );
+
     return DomBuilder.getInstance().build({
       type: 'div',
       classNames: [ 'mynah-chat-prompt-quick-picks-overlay-wrapper' ],
       children: [
-        ...(this.quickPickType === 'quick-action' && headerInfo != null
+        ...(this.quickPickType === 'quick-action' && hasHeaderContent
           ? [ headerComponent ]
           : []),
         this.quickPickItemsSelectorContainer.render

--- a/src/static.ts
+++ b/src/static.ts
@@ -474,6 +474,7 @@ export interface ChatItem extends ChatItemContent {
   status?: Status;
   shimmer?: boolean;
   collapse?: boolean;
+  border?: boolean;
 }
 
 export interface ValidationPattern {


### PR DESCRIPTION
## Problem
When the commandActionHeader is empty, there is an extra space on top of the quickActions.
![image](https://github.com/user-attachments/assets/0fb54893-4ca6-44a1-913e-2ea723df8443)

## Solution
Add check condition to only show the component when the header is not empty
![image](https://github.com/user-attachments/assets/df087f5c-784d-4abc-bcc8-979be05de75c)

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
