### PR TITLE
fix: Adding border and background color to chat item card summary

### DIFF
--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -420,6 +420,10 @@
                 display: flex;
                 flex-flow: row nowrap;
                 align-items: center;
+                // Adding background color and border for chat summary header
+                background-color: var(--mynah-card-bg);
+                border: var(--mynah-border-width) solid var(--mynah-color-border-default);
+                border-radius: var(--mynah-card-radius);
                 > .mynah-chat-item-summary-button {
                     margin-right: calc(-1 * var(--mynah-sizing-1));
                 }
@@ -427,7 +431,6 @@
             > .mynah-chat-item-card-summary-collapsed-content {
                 display: none;
                 flex-flow: column nowrap;
-                gap: var(--mynah-chat-wrapper-spacing);
             }
             &.show-summary > .mynah-chat-item-card-summary-collapsed-content {
                 display: flex;


### PR DESCRIPTION
## Problem
- No border and background color to the header
- Gap between Parameters box and Results box.

## Solution
![image](https://github.com/user-attachments/assets/474d5a83-316e-4acd-b8ff-ca046c21c386)
![image](https://github.com/user-attachments/assets/3e7c2523-67f3-4466-bc97-6167600da15e)

#### VSC Amazon Q:

https://github.com/user-attachments/assets/707b33f6-321d-4aa8-9601-96df1694e20b


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
