### PR TITLE
fix(text-input): validation error appears even if field is not changed, add validateOnChange prop

### DIFF
--- a/docs/DATAMODEL.md
+++ b/docs/DATAMODEL.md
@@ -1176,6 +1176,7 @@ export type TextBasedFormItem = BaseFormItem & {
   type: 'textarea' | 'textinput' | 'numericinput' | 'email';
   autoFocus?: boolean;
   checkModifierEnterKeyPress?: boolean;
+  validateOnChange?: boolean;
   validationPatterns?: {
     operator?: 'and' | 'or';
     genericValidationErrorMessage?: string;
@@ -2802,6 +2803,7 @@ interface ChatItemFormItem {
   placeholder?: string; // Placeholder for input, but only applicable to textarea, textinput and numericinput
   value?: string; // Initial value of the item. All types of form items will get and return string values, conversion of the value type is up to you
   checkModifierEnterKeyPress?: boolean; // Only applicable to textual inputs: whether the onFormModifierEnterPress event can be triggered from this input field
+  validateOnChange?: boolean; // Only applicable to text input: whether the form should validate on this field's change. If this field is false (or not set), form will validate onBlur by default
   options?: Array<{ // Only applicable to select and radiogroup types
     value: string;
     label: string;

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -1799,6 +1799,7 @@ here to see if it gets cut off properly as expected, with an ellipsis through cs
                     placeholder: 'Enter prompt name',
                     description: "Use this prompt by typing '@' followed by the prompt name.",
                     autoFocus: true,
+                    validateOnChange: true
                 },
             ],
             [

--- a/src/components/chat-item/chat-item-form-items.ts
+++ b/src/components/chat-item/chat-item-form-items.ts
@@ -181,6 +181,7 @@ export class ChatItemFormItemsWrapper {
               value,
               mandatory: chatItemOption.mandatory,
               validationPatterns: chatItemOption.validationPatterns,
+              validateOnChange: chatItemOption.validateOnChange,
               placeholder: chatItemOption.placeholder,
               ...(this.getHandlers(chatItemOption))
             });

--- a/src/components/form-items/text-input.ts
+++ b/src/components/form-items/text-input.ts
@@ -25,6 +25,7 @@ export interface TextInputProps {
     operator?: 'and' | 'or';
     patterns: ValidationPattern[];
   };
+  validateOnChange?: boolean;
   value?: string;
   onChange?: (value: string) => void;
   onKeyPress?: (event: KeyboardEvent) => void;
@@ -43,6 +44,7 @@ export class TextInputInternal extends TextInputAbstract {
   private readonly validationErrorBlock: ExtendedHTMLElement;
   private readonly props: TextInputProps;
   private readyToValidate: boolean = false;
+  private touched: boolean = false;
   render: ExtendedHTMLElement;
   constructor (props: TextInputProps) {
     StyleLoader.getInstance().load('components/_form-input.scss');
@@ -71,13 +73,20 @@ export class TextInputInternal extends TextInputAbstract {
       },
       events: {
         blur: (e) => {
-          this.readyToValidate = true;
+          // Only show validation error if user changed the input
+          if (this.touched) {
+            this.readyToValidate = true;
+          }
           this.checkValidation();
         },
         input: (e) => {
           if (this.props.onChange !== undefined) {
             this.props.onChange((e.currentTarget as HTMLInputElement).value);
           }
+          if (props.validateOnChange === true) {
+            this.readyToValidate = true;
+          }
+          this.touched = true;
           this.checkValidation();
         },
         keydown: (e: KeyboardEvent) => {

--- a/src/static.ts
+++ b/src/static.ts
@@ -503,6 +503,7 @@ export type TextBasedFormItem = BaseFormItem & {
     genericValidationErrorMessage?: string;
     patterns: ValidationPattern[];
   };
+  validateOnChange?: boolean;
 };
 
 type DropdownFormItem = BaseFormItem & {


### PR DESCRIPTION
## Problem
There are two issues with how validation works on TextInput

- Validation error only appears onBlur. On single-item forms this leads to a confusing UX since submit button is disabled but no error message is shown (see recording)
- Validation error message appears onBlur even when the field hasn't been changed. When a field's autofocus is true, and user clicks `X` to exit the form, an error message shows up. (see recording)

## Solution
- Add optional `validateOnChange` prop to TextInput. This allows consumers to opt-in to validation happening onChange for a specific field
- Only show validation error onBlur if user has touched the field


Screen recording **before fix**:

https://github.com/user-attachments/assets/f8619e36-f675-4c0b-9382-600c5283c15e



Screen recording **after fix**:


https://github.com/user-attachments/assets/532de5b8-dfaa-4546-a09d-77ea121b6a99




<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
