### PR TITLE
feat: call onSearchShortcut on ctrl/cmd + f

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -56,6 +56,7 @@ interface ConfigModel {
     maxTabs: number; // set 1 to hide tabs panel
     showPromptField: boolean; // shows prompt field (default: true)
     dragOverlayIcon?: MynahIcons | MynahIconsType | CustomIcon; // icon displayed in the overlay when a file is dragged into the chat area
+    enableSearchKeyboardShortcut?: boolean; // if true, calls onSearchShortcut on Command + f or Ctrl + f (default: false)
 }
 ...
 ```
@@ -406,3 +407,11 @@ Specifies the icon to display in the drag-and-drop overlay for adding files (suc
 <p align="center">
   <img src="./img/dragOverlayIcon.png" alt="noPrompt" style="max-width:500px; width:100%;border: 1px solid #e0e0e0;">
 </p>
+
+## enableSearchKeyboardShortcut
+
+**Type:** `boolean`
+
+When set to `true`, this option enables capturing the search keyboard shortcut. When enabled, pressing Command+F (Mac) or Ctrl+F (Windows/Linux) will trigger the `onSearchShortcut` event instead of the browser's default search behavior. This allows implementing custom search functionality within the chat interface.
+
+Default: `false`

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -1296,3 +1296,23 @@ onFilesDropped: (tabId, files, insertPosition) => {
 ```
 
 ---
+
+### `onSearchShortcut`
+
+This event will be fired when the user presses Command+F (Mac) or Ctrl+F (Windows/Linux). It passes the `tabId` of the current tab and the `eventId` for tracking user intent. This allows the consumer to implement custom search functionality when the standard browser search shortcut is pressed.
+
+```typescript
+...
+onSearchShortcut?: (
+    tabId: string,
+    eventId?: string) => void;
+...
+```
+
+**Example:**
+```typescript
+onSearchShortcut: (tabId, eventId) => {
+  console.log(`Search shortcut triggered in tab: ${tabId}`);
+  // Implement custom search functionality, such as opening a history sheet
+},
+```

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -84,7 +84,6 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
             noMoreTabsTooltip: 'You can only open five conversation tabs at a time.',
             autoFocus: true,
             dragOverlayIcon: MynahIcons.IMAGE,
-            enableSearchKeyboardShortcut: true,
             texts: {
                 dragOverlayText: 'Add Image to Context',
                 stopGeneratingTooltip: 'Stop &#8984; Backspace',

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -84,6 +84,7 @@ export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
             noMoreTabsTooltip: 'You can only open five conversation tabs at a time.',
             autoFocus: true,
             dragOverlayIcon: MynahIcons.IMAGE,
+            enableSearchKeyboardShortcut: true,
             texts: {
                 dragOverlayText: 'Add Image to Context',
                 stopGeneratingTooltip: 'Stop &#8984; Backspace',
@@ -1036,6 +1037,9 @@ here to see if it gets cut off properly as expected, with an ellipsis through cs
         },
         onTabAdd: (tabId: string) => {
             Log(`New tab added: <b>${tabId}</b>`);
+        },
+        onSearchShortcut: (tabId: string) => {
+            Log(`Search shortcut pressed on tab: <b>${tabId}</b>`);
         },
         onOpenFileDialogClick: (tabId: string, fileType: string, insertPosition: number) => {
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ import {
   TreeNodeDetails,
   Action,
 } from './static';
-import { MynahUIGlobalEvents } from './helper/events';
+import { cancelEvent, MynahUIGlobalEvents } from './helper/events';
 import { Tabs } from './components/navigation-tabs';
 import { ChatWrapper } from './components/chat-item/chat-wrapper';
 import { FeedbackForm } from './components/feedback-form/feedback-form';
@@ -165,6 +165,9 @@ export interface MynahUIProps {
     eventId?: string
   ) => boolean;
   onTabRemove?: (
+    tabId: string,
+    eventId?: string) => void;
+  onSearchShortcut?: (
     tabId: string,
     eventId?: string) => void;
   /**
@@ -479,6 +482,20 @@ export class MynahUI {
     this.focusToInput(tabId);
     if (this.props.onReady !== undefined) {
       this.props.onReady();
+    }
+    if (Config.getInstance().config.enableSearchKeyboardShortcut === true) {
+      document.addEventListener('keydown', (e) => {
+        // Check for Command+F (Mac) or Ctrl+F (Windows/Linux)
+        if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+          cancelEvent(e);
+          // Call the search shortcut handler with the current tab ID
+          if (this.props.onSearchShortcut !== undefined) {
+            this.props.onSearchShortcut(
+              MynahUITabsStore.getInstance().getSelectedTabId(),
+              this.getUserEventId());
+          }
+        }
+      });
     }
   }
 

--- a/src/static.ts
+++ b/src/static.ts
@@ -792,6 +792,7 @@ export interface ConfigOptions {
   codeCopyToClipboardEnabled?: boolean;
   test?: boolean;
   dragOverlayIcon?: MynahIcons | MynahIconsType | CustomIcon;
+  enableSearchKeyboardShortcut?: boolean;
 }
 
 export interface ConfigModel extends ConfigOptions {


### PR DESCRIPTION
### Problem
Currently, there is no way to intercept and handle the standard search shortcut (Cmd+F/Ctrl+F) within Mynah UI. Users want to be able to open chat history search with a keyboard shortcut.

### Solution
Changes include:

- Added `enableSearchKeyboardShortcut` to config so consumers can opt-in to enable the keyboard shortcut 
- Added a new `onSearchShortcut` event handler that fires on Cmd+F or Ctrl+F
- Prevents the default search behavior
- Provides the current tab ID and event ID to the consumer for custom implementation
- Added documentation in `PROPERTIES.md` and `CONFIG.md`
- Implemented the event handler in the main MynahUI class

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [x] I have tested this change on JetBrains
- [x] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
