### PR TITLE
add public setDragOverlayVisible and resetTopBarClicked methods

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -30,6 +30,8 @@ mynahUI.showCustomForm(...);
 mynahUI.updateTabDefaults(...);
 mynahUI.toggleSplashLoader(...);
 mynahUI.addCustomContextToPrompt(...);
+mynahUI.resetTopBarClicked(...);
+mynahUI.setDragOverlayVisible(...);
 mynahUI.destroy();
 ```
 
@@ -710,3 +712,40 @@ When called, this function will:
 - Update the tab's data store so that the custom context is tracked and can be referenced or removed later.
 
 **Note:** If the prompt input is not currently visible or the tab does not exist, the function will have no effect.
+
+---
+
+# Show or hide the drag-and-drop overlay (`setDragOverlayVisible`)
+
+Show or hide the drag-and-drop overlay for a specific tab programmatically.
+
+**Signature:**
+```ts
+setDragOverlayVisible(tabId: string, visible: boolean): void
+```
+
+- `tabId`: The ID of the tab for which to show/hide the overlay.
+- `visible`: `true` to show the overlay, `false` to hide it.
+
+**Example:**
+```ts
+mynahUI.setDragOverlayVisible('tab-1', true);  // Show overlay
+mynahUI.setDragOverlayVisible('tab-1', false); // Hide overlay
+```
+
+---
+# Reset Top Bar Clicked Method (`resetTopBarClicked`)
+
+Programmatically resets topBarClicked for the specified tab by dispatching a RESET_TOP_BAR_CLICKED event. This is useful for scenarios like drag-and-drop
+
+**Signature:**
+```ts
+resetTopBarClicked(tabId: string): void
+```
+
+- `tabId`: The ID of the tab for which to reset the top bar overlay.
+
+**Example:**
+```ts
+mynahUI.resetTopBarClicked('tab-1');
+```

--- a/src/components/chat-item/chat-wrapper.ts
+++ b/src/components/chat-item/chat-wrapper.ts
@@ -527,7 +527,7 @@ export class ChatWrapper {
     return this.promptInput?.getCurrentTriggerSource?.() ?? 'prompt-input';
   }
 
-  private setDragOverlayVisible (visible: boolean): void {
+  public setDragOverlayVisible (visible: boolean): void {
     if (this.dragOverlayVisibility === visible) return;
     this.dragOverlayVisibility = visible;
     this.dragOverlayContent.style.display = visible ? 'flex' : 'none';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1038,6 +1038,25 @@ export class MynahUI {
   public getTabData = (tabId: string): MynahUIDataStore => MynahUITabsStore.getInstance().getTabDataStore(tabId);
 
   /**
+   * Sets the drag overlay visibility for a specific tab
+   * @param tabId The tab ID to set the drag overlay visibility for
+   * @param visible Whether the drag overlay should be visible
+   */
+  public setDragOverlayVisible = (tabId: string, visible: boolean): void => {
+    if (this.chatWrappers[tabId] !== null) {
+      this.chatWrappers[tabId].setDragOverlayVisible(visible);
+    }
+  };
+
+  /**
+   * Programmatically resets topBarClicked for the specified tab by dispatching a RESET_TOP_BAR_CLICKED event.
+   * @param tabId The tab ID
+   */
+  public resetTopBarClicked = (tabId: string): void => {
+    MynahUIGlobalEvents.getInstance().dispatch(MynahEventNames.RESET_TOP_BAR_CLICKED, { tabId });
+  };
+
+  /**
    * Toggles the visibility of the splash loader screen
    */
   public toggleSplashLoader = (visible: boolean, text?: string, actions?: Action[]): void => {


### PR DESCRIPTION
## Problem
Fix the bug
1) Dragging an image sometimes adds it to pinned context instead of in the prompt 
2) Drag overlay is not rendered 

## Solution
* Add two public method that can be used by consumer
 1. Show/Hide drag overlay
 2. Reset the topBarClicked, this is the variable controls whether context is added to pinned context or prompt


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ x ] I have tested this change on VSCode
- [ x ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
