### PR TITLE
fix: UI Improvements for Non-Chat Tabs and Icon Wrapper Optimization

### DIFF
--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -33,6 +33,11 @@ export const tabbarButtons: TabBarMainAction[] = [
                 icon: MynahIcons.Q,
             },
             {
+                id: 'account-details',
+                text: 'Non chat tab (Account Details)',
+                icon: MynahIcons.USER,
+            },
+            {
                 id: 'splash-loader',
                 text: 'Show splash loader',
                 icon: MynahIcons.PAUSE,

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -53,6 +53,7 @@ import {
     mcpToolRunSampleCard,
     mcpToolRunSampleCardInit,
     sampleRulesList,
+    accountDetailsTabData,
 } from './samples/sample-data';
 import escapeHTML from 'escape-html';
 import './styles/styles.scss';
@@ -990,6 +991,8 @@ here to see if it gets cut off properly as expected, with an ellipsis through cs
                     ...mynahUIDefaults.store,
                     ...welcomeScreenTabData.store,
                 });
+            } else if (buttonId === 'account-details') {
+                mynahUI.updateStore('', accountDetailsTabData);
             } else if (buttonId === 'export-chat-md') {
                 const serializedChat = mynahUI.serializeChat(tabId, 'markdown');
                 const blob = new Blob([serializedChat], { type: 'text/plain' });

--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -445,6 +445,39 @@ Transform your java project from an old version to a new one.
     ],
 };
 
+export const accountDetailsTabData: MynahUIDataModel = {
+    tabBackground: false,
+    compactMode: false,
+    tabTitle: 'Account Details',
+    promptInputVisible: false,
+    tabHeaderDetails: {
+        title: `Account details`,
+    },
+    chatItems: [
+        {
+            type: ChatItemType.ANSWER,
+            body: `### Subscription
+Free Tier
+`,
+            buttons: [
+                {
+                    status: 'primary',
+                    id: 'upgrade-subscription',
+                    text: `Upgrade`,
+                },
+            ],
+        },
+        {
+            type: ChatItemType.ANSWER,
+            body: `### Usage
+591/1000 queries used
+$0.00 incurred in overages
+Limits reset on 8/1/2025 at 12:00:00 GMT
+`,
+        },
+    ],
+};
+
 export const qAgentQuickActions: MynahUIDataModel['quickActionCommands'] = [
     {
         commands: [

--- a/src/components/title-description-with-icon.ts
+++ b/src/components/title-description-with-icon.ts
@@ -24,7 +24,11 @@ export class TitleDescriptionWithIcon {
     this.render = DomBuilder.getInstance().build({
       type: 'div',
       testId: props.testId,
-      classNames: [ 'mynah-ui-title-description-icon-wrapper', ...(this.props.classNames ?? []) ],
+      // Apply icon wrapper styles only if icon is provided
+      classNames: [
+        ...(this.props.icon !== undefined ? [ 'mynah-ui-title-description-icon-wrapper' ] : []),
+        ...(this.props.classNames ?? [])
+      ],
       children: [
         ...(this.props.icon !== undefined
           ? [ {


### PR DESCRIPTION
## Problem
- When no icon is provided in `tabHeaderDetails`, the `mynah-ui-title-description-icon-wrapper` class adds unwanted left padding. 
<img width="1266" height="570" alt="image" src="https://github.com/user-attachments/assets/7e887069-17f0-4d65-b314-bc0bc766e6e2" />

## Solution
- Modified `title-description-with-icon.ts` to conditionally apply icon wrapper styles.
- Only applies the `mynah-ui-title-description-icon-wrapper` class when an icon is provided
- Improves layout consistency when no icon is present
- The changes have been tested in the example application and work as expected.
<img width="1266" height="596" alt="image" src="https://github.com/user-attachments/assets/cb6a9dbf-33c4-46e1-a146-ab39dd52fba1" />

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
