### PR TITLE
fix: hide prompt top bar when progress indicator is visible

### DIFF
--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -371,6 +371,9 @@
                 > .mynah-chat-prompt-button-wrapper {
                     display: none;
                 }
+                > .mynah-prompt-input-top-bar {
+                    display: none;
+                }
             }
         }
 


### PR DESCRIPTION
## Problem
The prompt top bar was stretching the height of the progress indicator, and items in the top bar were still visible.

## Solution
Hide the prompt top bar when the progress indicator is visible.

Screenshots

Before fix:
<img width="853" height="1077" alt="Screenshot 2025-07-16 at 11 34 14 AM" src="https://github.com/user-attachments/assets/4774c3f4-a34c-4ce0-9009-f9ac4f4275c1" />


After fix:
<img width="905" height="1037" alt="Screenshot 2025-07-16 at 11 33 39 AM" src="https://github.com/user-attachments/assets/14d3b6d4-9375-48d9-991a-459aca07c989" />

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [x] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
