### PR TITLE
fix: do not auto-select first element in detailed list

### DIFF
--- a/src/__test__/components/detailed-list/detailed-list.spec.ts
+++ b/src/__test__/components/detailed-list/detailed-list.spec.ts
@@ -574,6 +574,7 @@ describe('DetailedListWrapper Component', () => {
     it('should get target element', () => {
       detailedListWrapper = new DetailedListWrapper({ detailedList: basicDetailedList });
       document.body.appendChild(detailedListWrapper.render);
+      detailedListWrapper.changeTarget('down', false, true);
 
       const targetElement = detailedListWrapper.getTargetElement();
       expect(targetElement).toBeDefined();
@@ -615,6 +616,9 @@ describe('DetailedListWrapper Component', () => {
       detailedListWrapper = new DetailedListWrapper({ detailedList: basicDetailedList });
       document.body.appendChild(detailedListWrapper.render);
 
+      // First select the first item
+      detailedListWrapper.changeTarget('down');
+
       // Go up from first item (should wrap to last)
       detailedListWrapper.changeTarget('up', false);
       const targetElement = detailedListWrapper.getTargetElement();
@@ -625,7 +629,9 @@ describe('DetailedListWrapper Component', () => {
       detailedListWrapper = new DetailedListWrapper({ detailedList: basicDetailedList });
       document.body.appendChild(detailedListWrapper.render);
 
-      // Move to last item first
+      // First select an item
+      detailedListWrapper.changeTarget('down');
+      // Move to last item
       detailedListWrapper.changeTarget('down');
       // Then go down (should wrap to first)
       detailedListWrapper.changeTarget('down', false);
@@ -636,6 +642,9 @@ describe('DetailedListWrapper Component', () => {
     it('should handle navigation with snap at boundaries', () => {
       detailedListWrapper = new DetailedListWrapper({ detailedList: basicDetailedList });
       document.body.appendChild(detailedListWrapper.render);
+
+      // First select the first item
+      detailedListWrapper.changeTarget('down');
 
       // Go up with snap (should stay at first)
       detailedListWrapper.changeTarget('up', true);

--- a/src/components/detailed-list/detailed-list-item.ts
+++ b/src/components/detailed-list/detailed-list-item.ts
@@ -17,6 +17,7 @@ export interface DetailedListItemWrapperProps {
   onSelect?: (detailedListItem: DetailedListItem) => void;
   onClick?: (detailedListItem: DetailedListItem) => void;
   onActionClick?: (action: ChatItemButton, detailedListItem?: DetailedListItem) => void;
+  onShowActionMenuOverlay?: () => void;
   selectable?: boolean;
   clickable?: boolean;
   textDirection?: 'row' | 'column';
@@ -201,6 +202,7 @@ export class DetailedListItemWrapper {
   };
 
   private readonly showActionMenuOverlay = (listItem?: DetailedListItem): void => {
+    this.props.onShowActionMenuOverlay?.();
     this.actionMenuOverlay = new Overlay({
       background: true,
       closeOnOutsideClick: true,


### PR DESCRIPTION
## Problem
The current implementation of the DetailedListWrapper component has several issues with keyboard navigation and focus management:

1. The component automatically focuses the first item on initialization, which can be disruptive/confusing to users
2. When clicking to open an item's action menu, focus is not set to the clicked item (see screen recording)

## Solution
This PR improves the detailed list navigation and focus management with the following changes:

1. Initial focus state: Changed the default activeTargetElementIndex from 0 to -1 to indicate no item is initially selected
2. Focus management: 
   • Removed automatic focus of first item on initialization
   • Added proper focus handling when action menu overlays are shown





Screenshots:


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
