### PR TITLE
feat: add option to disable dropdown form item

### DIFF
--- a/src/components/chat-item/chat-item-form-items.ts
+++ b/src/components/chat-item/chat-item-form-items.ts
@@ -110,6 +110,9 @@ export class ChatItemFormItemsWrapper {
               placeholder: chatItemOption.placeholder ?? Config.getInstance().config.texts.pleaseSelect,
               ...(this.getHandlers(chatItemOption))
             });
+            if (chatItemOption.disabled === true) {
+              chatOption.setEnabled(false);
+            }
             break;
           case 'radiogroup':
           case 'toggle':

--- a/src/static.ts
+++ b/src/static.ts
@@ -514,6 +514,7 @@ type DropdownFormItem = BaseFormItem & {
     value: string;
     label: string;
   }>;
+  disabled?: boolean;
 };
 
 type Stars = BaseFormItem & {


### PR DESCRIPTION
## Problem

Cannot disable dropdown/select form item. We to support this for more use cases

## Solution

Add `disabled` prop to `DropdownFormItem` to disable it in `ChatItemFormItemsWrapper`

## Screenshots

<img width="537" height="74" alt="Screenshot 2025-07-16 at 4 05 52 PM" src="https://github.com/user-attachments/assets/7d7e0bc4-a1d7-4c69-979e-0cffd137fb01" />

VSC Screenshot:

<img width="399" height="97" alt="Screenshot 2025-07-16 at 4 04 08 PM" src="https://github.com/user-attachments/assets/95b282da-0ca9-41e6-ac84-9ed5c2aaf1d2" />


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
