### PR TITLE
fix: remove the console log statement in example data

### DIFF
--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -1329,7 +1329,6 @@ here to see if it gets cut off properly as expected, with an ellipsis through cs
                     commands.push(contextItem);
                 }
             }
-            console.log(commands)
             mynahUI.addCustomContextToPrompt(tabId, commands, insertPosition);
         },
         onInBodyButtonClicked: (tabId: string, messageId: string, action) => {


### PR DESCRIPTION
## Problem
During the development, there's a `console.log()` used for testing was accidentally added.

## Solution
Remove the console log.
<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
