### PR TITLE
fix: decrease dropdown arrow spacing and always have border around prompt input box

### DIFF
--- a/src/styles/components/chat/_chat-prompt-wrapper.scss
+++ b/src/styles/components/chat/_chat-prompt-wrapper.scss
@@ -250,13 +250,14 @@
                                 }
                                 > .mynah-form-input-container.no-border {
                                     > .select-auto-width-sizer {
+                                        font-size: var(--mynah-font-size-xsmall);
                                         padding-right: calc(var(--mynah-sizing-half) + 1em);
                                     }
                                     > select {
                                         width: auto;
                                         min-width: auto;
                                         color: var(--mynah-color-text-default);
-                                        font-size: var(--mynah-font-size-small);
+                                        font-size: var(--mynah-font-size-xsmall);
                                         & + i {
                                             font-size: var(--mynah-font-size-xsmall);
                                         }
@@ -392,7 +393,7 @@
             pointer-events: none;
         }
         &::before {
-            border: var(--mynah-border-width) solid var(--mynah-color-text-input-border);
+            border: var(--mynah-border-width) solid var(--mynah-color-text-input-border-focused);
         }
     }
 


### PR DESCRIPTION
## Problem
- dropdown arrow spacing has too much spacing
- font size for dropdown options is too large
- we don't have a border if prompt input box is not in focus

## Solution
- decrease spacing for dropdown arrow 
- decrease dropdown font size from `mynah-font-size-small` to `mynah-font-size-xsmall`
- always have border around prompt input box even when not in focus

## Visuals for dropdown

#### Old mynahui:
<img width="736" height="226" alt="old" src="https://github.com/user-attachments/assets/675d3dfa-9085-44a9-8ca9-b367bad75f91" />

#### New mynahui:
<img width="738" height="274" alt="new" src="https://github.com/user-attachments/assets/fa312392-af12-46a6-99f8-12094891d7eb" />

#### Old and new VSC:
<img width="382" height="133" alt="old vsc" src="https://github.com/user-attachments/assets/85f98d51-bd8c-4b5b-a4f7-db4574ea578a" />

<img width="384" height="140" alt="new vsc" src="https://github.com/user-attachments/assets/515a096e-b8a7-48f4-9614-c0c650340a56" />


## Visuals for border

#### Out of focus border:
<img width="674" height="188" alt="out of focus" src="https://github.com/user-attachments/assets/b6195de2-8f5a-4392-9cb5-031aa7ec0565" />

#### In focus border:
<img width="675" height="185" alt="in focus" src="https://github.com/user-attachments/assets/d6549d0c-4d7a-4426-8106-fdf6fac8cf37" />

#### Now the border always shows (regardless of in focus or out of focus):
https://github.com/user-attachments/assets/6795de13-505f-48b0-86ab-f2b646481ba1


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
