### PR TITLE
Bumping version to v4.36.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/mynah-ui",
-    "version": "4.36.1",
+    "version": "4.36.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/mynah-ui",
-            "version": "4.36.1",
+            "version": "4.36.2",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws/mynah-ui",
     "displayName": "AWS Mynah UI",
-    "version": "4.36.1",
+    "version": "4.36.2",
     "description": "AWS Toolkit VSCode and Intellij IDE Extension Mynah UI",
     "publisher": "Amazon Web Services",
     "license": "Apache License 2.0",


### PR DESCRIPTION
## What's Changed
* fix: add log by using Log() function by @yzhangok in https://github.com/aws/mynah-ui/pull/411
* fix: decrease dropdown arrow spacing by @chungjac in https://github.com/aws/mynah-ui/pull/414


## Change's Screenshots

Use the Console on the right side of the MynahUI example page for logging.

<img width="1289" height="706" alt="Screenshot 2025-07-23 at 3 34 00 PM" src="https://github.com/user-attachments/assets/b779ddbf-3706-494c-9663-2f4a43a49979" />


## Visuals for dropdown

#### Old mynahui:
<img width="736" height="226" alt="old" src="https://github.com/user-attachments/assets/675d3dfa-9085-44a9-8ca9-b367bad75f91" />

#### New mynahui:
<img width="738" height="274" alt="new" src="https://github.com/user-attachments/assets/fa312392-af12-46a6-99f8-12094891d7eb" />

#### Old and new VSC:
<img width="382" height="133" alt="old vsc" src="https://github.com/user-attachments/assets/85f98d51-bd8c-4b5b-a4f7-db4574ea578a" />

<img width="384" height="140" alt="new vsc" src="https://github.com/user-attachments/assets/515a096e-b8a7-48f4-9614-c0c650340a56" />


#### Out of focus border:
<img width="674" height="188" alt="out of focus" src="https://github.com/user-attachments/assets/b6195de2-8f5a-4392-9cb5-031aa7ec0565" />

#### In focus border:
<img width="675" height="185" alt="in focus" src="https://github.com/user-attachments/assets/d6549d0c-4d7a-4426-8106-fdf6fac8cf37" />

#### Now the border always shows (regardless of in focus or out of focus):
https://github.com/user-attachments/assets/6795de13-505f-48b0-86ab-f2b646481ba1

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
