### PR TITLE
feat: allow pending display for ContextCommands

### DIFF
--- a/src/components/detailed-list/detailed-list-item.ts
+++ b/src/components/detailed-list/detailed-list-item.ts
@@ -89,17 +89,25 @@ export class DetailedListItemWrapper {
               : [])
           ]
         },
-        ...((this.props.listItem.children != null) && this.props.listItem.children.length > 0
+        ...(this.props.listItem.pending === true
           ? [
               {
                 type: 'div',
-                classNames: [ 'mynah-detailed-list-item-arrow-icon' ],
-                children: [
-                  new Icon({ icon: 'right-open' }).render
-                ]
+                classNames: [ 'mynah-detailed-list-item-pending' ],
+                children: [ '(pending)' ]
               }
             ]
-          : []),
+          : (this.props.listItem.children != null) && this.props.listItem.children.length > 0
+              ? [
+                  {
+                    type: 'div',
+                    classNames: [ 'mynah-detailed-list-item-arrow-icon' ],
+                    children: [
+                      new Icon({ icon: 'right-open' }).render
+                    ]
+                  }
+                ]
+              : []),
         ...(this.props.listItem.status != null
           ? [
               DomBuilder.getInstance().build({

--- a/src/helper/quick-pick-data-handler.ts
+++ b/src/helper/quick-pick-data-handler.ts
@@ -171,7 +171,8 @@ export const convertQuickActionCommandToDetailedListItem = (quickActionCommand: 
     disabled: quickActionCommand.disabled,
     icon: quickActionCommand.icon,
     id: quickActionCommand.id,
-    keywords: quickActionCommand.route
+    keywords: quickActionCommand.route,
+    pending: quickActionCommand.pending
   };
 };
 

--- a/src/static.ts
+++ b/src/static.ts
@@ -33,6 +33,7 @@ export interface QuickActionCommand {
   placeholder?: string;
   children?: QuickActionCommandGroup[];
   route?: string[];
+  pending?: boolean;
 }
 export interface CustomQuickActionCommand extends QuickActionCommand {
   content?: Uint8Array;
@@ -346,6 +347,7 @@ export interface DetailedListItem {
     icon?: MynahIcons | MynahIconsType;
     text?: string;
   };
+  pending?: boolean;
 }
 
 export type Status = 'info' | 'success' | 'warning' | 'error';

--- a/src/styles/components/_detailed-list.scss
+++ b/src/styles/components/_detailed-list.scss
@@ -291,6 +291,13 @@
                         color: var(--mynah-color-text-weak);
                         font-size: var(--mynah-font-size-small);
                     }
+
+                    > .mynah-detailed-list-item-pending {
+                        flex-shrink: 0;
+                        color: var(--mynah-color-text-weak);
+                        font-size: var(--mynah-font-size-small);
+                        font-style: italic;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem
In large workspaces, indexing can take a long time with no indication of status
## Solution
This allows for an initial pending state for files, folders, code, and workspace which is turned off individually once indexing is complete for that item
<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
