### PR TITLE
fix: remove existing status before updating with a new one

### DIFF
--- a/src/components/chat-item/chat-item-card.ts
+++ b/src/components/chat-item/chat-item-card.ts
@@ -447,6 +447,8 @@ export class ChatItemCard {
       }
 
       if (this.props.chatItem.header.status != null) {
+        // Remove existing status before adding new one
+        this.cardHeader?.querySelector('.mynah-chat-item-card-header-status')?.remove();
         this.cardHeader?.insertAdjacentElement(this.props.chatItem.header.status.position === 'left' ? 'afterbegin' : 'beforeend', DomBuilder.getInstance().build({
           type: 'span',
           classNames: [ 'mynah-chat-item-card-header-status', `status-${this.props.chatItem.header.status.status ?? 'default'}` ],


### PR DESCRIPTION
## Problem

Duplicate header status
<img width="660" height="529" alt="Screenshot 2025-08-04 at 7 01 33 PM" src="https://github.com/user-attachments/assets/bf587f83-9e54-447a-9505-cdcb4bdc48b0" />


## Solution

Remove existing header status before updating cards with a new one

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
