### PR TITLE
feat: support markdown when renderAsPills is true

### DIFF
--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -2035,11 +2035,13 @@ mkdir -p src/ lalalaaaa sad fbnsafsdaf sdakjfsd sadf asdkljf basdkjfh ksajhf kjs
                 details: {
                     'src/components/ui': {
                         visibleName: 'ui',
-                        description: 'src/components/ui'
+                        description: 'src/components/ui',
+                        clickable: false
                     },
                     'src/components/forms': {
                         visibleName: 'forms',
-                        description: 'src/components/forms'
+                        description: 'src/components/forms',
+                        clickable: false
                     },
                 },
                 renderAsPills: true
@@ -2059,27 +2061,55 @@ mkdir -p src/ lalalaaaa sad fbnsafsdaf sdakjfsd sadf asdkljf basdkjfh ksajhf kjs
                     'src/components/ui': {
                         visibleName: 'ui',
                         description: 'src/components/ui',
+                        clickable: false
                     },
                     'src/components/forms': {
                         visibleName: 'forms',
-                        description: 'src/components/forms'
+                        description: 'src/components/forms',
+                        clickable: false
                     },
                     'src/components/layout': {
                         visibleName: 'layout',
-                        description: 'src/components/layout'
+                        description: 'src/components/layout',
+                        clickable: false
                     },
                     'src/utils/helpers': {
                         visibleName: 'helpers',
-                        description: 'src/components/helpers'
+                        description: 'src/components/helpers',
+                        clickable: false
                     },
                     'src/utils/validation': {
                         visibleName: 'validation',
-                        description: 'src/components/validation'
+                        description: 'src/components/validation',
+                        clickable: false
                     },
                 },
                 renderAsPills: true
             }
         }
+    },
+    {
+        type: ChatItemType.ANSWER,
+        fullWidth: true,
+        padding: false,
+        header: {
+            icon: 'search',
+            body: 'Searched for `*.md` in',
+            fileList: {
+                filePaths: ['src/docs'],
+                details: {
+                    ['src/docs']: {
+                        visibleName: 'docs',
+                        description: 'src/docs',
+                        clickable: false
+                    }
+                },
+                renderAsPills: true
+            },
+            status: {
+                text: '5 results found'
+            }
+        },
     }
 ];
 


### PR DESCRIPTION
## Problem

Custom renderer for pills doesn't support markdown

## Solution

- Add parseMarkdown helper to the customRenderer
- Also allow avoiding dispatching click events if `clickable` is explicitly set to false
<img width="617" height="66" alt="image" src="https://github.com/user-attachments/assets/6263e441-6459-4e20-b048-970477e4f951" />


<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
