### PR TITLE
feat: add button to collapse/expand long description in chat-item-form-items

### DIFF
--- a/src/styles/components/_detailed-list.scss
+++ b/src/styles/components/_detailed-list.scss
@@ -39,7 +39,7 @@
             display: none;
         }
         > .mynah-chat-item-form-items-container {
-            gap: var(--mynah-sizing-4);
+            gap: var(--mynah-sizing-5);
         }
     }
     > .mynah-detailed-list-filter-actions-wrapper {

--- a/src/styles/components/_form-input.scss
+++ b/src/styles/components/_form-input.scss
@@ -26,8 +26,76 @@
         }
     }
     .mynah-ui-form-item-description {
+        position: relative;
         font-size: var(--mynah-font-size-small);
         color: var(--mynah-color-text-weak);
+
+        .mynah-ui-form-item-description-content {
+            display: block;
+            line-height: 1.4;
+        }
+
+        &.mynah-ui-form-item-description-auto-collapse {
+            .mynah-ui-form-item-description-content {
+                position: relative;
+                
+                // Default state - no fade effect
+                &::after {
+                    content: '';
+                    position: absolute;
+                    bottom: 0;
+                    left: 0;
+                    right: 0;
+                    height: 1rem;
+                    background: linear-gradient(transparent, var(--mynah-color-bg));
+                    pointer-events: none;
+                    opacity: 0;
+                    transition: opacity 0.15s ease-in-out;
+                }
+            }
+
+            // Only show fade effect when collapsed
+            &.mynah-ui-form-item-description-collapsed {
+                .mynah-ui-form-item-description-content {
+                    max-height: var(--form-description-collapsed-height, 3.125vh); // window.innerHeight / 32
+                    overflow: hidden;
+                    transition: max-height 0.3s ease-in-out;
+                    
+                    &::after {
+                        opacity: 1;
+                    }
+                }
+            }
+
+            // When expanded, ensure no fade and smooth transition
+            &:not(.mynah-ui-form-item-description-collapsed) {
+                .mynah-ui-form-item-description-content {
+                    max-height: none;
+                    overflow: visible;
+                    transition: max-height 0.3s ease-in-out;
+                    
+                    &::after {
+                        opacity: 0;
+                    }
+                }
+            }
+        }
+
+        .more-content-indicator {
+            margin-top: var(--mynah-sizing-1);
+            
+            &.hidden {
+                display: none;
+            }
+        }
+
+        // Only remove shadow when expanded (not collapsed)
+        &:not(.mynah-ui-form-item-description-collapsed) {
+            .more-content-indicator {
+                box-shadow: none;
+                background-color: transparent;
+            }
+        }
     }
     .mynah-form-input-container {
         position: relative;


### PR DESCRIPTION
## Problem

Some description in filterOptions in detailed-list could be very long that it make very hard to navigate to another form-items

<img width="397" height="802" alt="Screenshot 2025-08-11 at 1 00 04 PM" src="https://github.com/user-attachments/assets/a24936b4-8612-4f3c-8c8d-cabe99d7fd27" />


## Solution

Make the description field collapsible if the length > 3 lines. 

Add a button to collapse/expand description

## Screenshots
### Webview
<img width="589" height="153" alt="Screenshot 2025-08-11 at 12 57 38 PM" src="https://github.com/user-attachments/assets/eee0de3a-8452-410f-9c85-f406ada5086e" />
<img width="581" height="219" alt="Screenshot 2025-08-11 at 12 57 46 PM" src="https://github.com/user-attachments/assets/b1911d82-f556-464b-8325-c26d160b9abb" />

### VSC

<img width="402" height="803" alt="Screenshot 2025-08-11 at 1 02 19 PM" src="https://github.com/user-attachments/assets/581a2449-614c-43e5-823b-c65388c59648" />

https://github.com/user-attachments/assets/b9cacfc6-bac9-4f4d-a27f-2e818c7560c5



<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [X] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
