### PR TITLE
fix: prevent element removal during scroll

### DIFF
--- a/src/components/detailed-list/detailed-list.ts
+++ b/src/components/detailed-list/detailed-list.ts
@@ -91,19 +91,23 @@ export class DetailedListWrapper {
   private readonly handleScroll = (): void => {
     const wrapperOffsetHeight = this.detailedListItemGroupsContainer.offsetHeight;
     const wrapperScrollTop = this.detailedListItemGroupsContainer.scrollTop;
+    const buffer = wrapperOffsetHeight;
+
     this.detailedListItemsBlockData.forEach(itemsBlock => {
       const itemBlockTop = itemsBlock.element.offsetTop;
-      const itemBlockBottom = itemsBlock.element.offsetTop + itemsBlock.element.offsetHeight;
-      if (itemsBlock.element.childNodes.length === 0 &&
-      (itemBlockTop < wrapperScrollTop + wrapperOffsetHeight) &&
-      (itemBlockBottom > wrapperScrollTop - wrapperOffsetHeight)) {
+      const itemBlockBottom = itemBlockTop + itemsBlock.element.offsetHeight;
+      const hasChildren = itemsBlock.element.childNodes.length > 0;
+
+      const isVisible = (itemBlockTop < wrapperScrollTop + wrapperOffsetHeight + buffer) &&
+                     (itemBlockBottom > wrapperScrollTop - buffer);
+
+      if (!hasChildren && isVisible) {
         // Block is visible but not rendered yet - add DOM elements
         itemsBlock.element.update({
           children: this.getDetailedListItemElements(itemsBlock.data)
         });
-      } else if ((itemBlockTop > wrapperScrollTop + wrapperOffsetHeight) ||
-    (itemBlockBottom < wrapperScrollTop - wrapperOffsetHeight)) {
-        // Block is no longer visible - remove DOM elements to save memory
+      } else if (hasChildren && !isVisible) {
+        // Block has children but is no longer visible - remove DOM elements
         itemsBlock.element.clear();
       }
     });


### PR DESCRIPTION
## Problem

- Dropdown list items disappear during scrolling when typing / in chat

## Solution

- Added buffer zone to visibility calculations in handleScroll method
- Cache DOM position measurements to prevent inconsistent calculations
- Use mutually exclusive conditions to prevent add/remove conflicts in same iteration

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
