### PR TITLE
feat: Bump up node version from 18 to 24

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@aws'
       - run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@aws'
       - run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@aws'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@aws'
       - name: Install dependencies and build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@aws'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "@types/jest": "^29.5.5",
                 "@types/json-schema": "7.0.7",
                 "@types/minimatch": "^5.1.2",
-                "@types/node": "17.0.29",
+                "@types/node": "^24.0.0",
                 "@types/sanitize-html": "^2.11.0",
                 "@typescript-eslint/eslint-plugin": "^5.34.0",
                 "@typescript-eslint/parser": "^5.62.0",
@@ -1749,10 +1749,14 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "17.0.29",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
-            "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
-            "dev": true
+            "version": "24.5.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.0.tgz",
+            "integrity": "sha512-y1dMvuvJspJiPSDZUQ+WMBvF7dpnEqN4x9DDC9ie5Fs/HUZJA3wFp7EhHoVaKX/iI0cRoECV8X2jL8zi0xrHCg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~7.12.0"
+            }
         },
         "node_modules/@types/sanitize-html": {
             "version": "2.11.0",
@@ -10213,6 +10217,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "7.12.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+            "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/unescape-html": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "@types/jest": "^29.5.5",
         "@types/json-schema": "7.0.7",
         "@types/minimatch": "^5.1.2",
-        "@types/node": "17.0.29",
+        "@types/node": "^24.0.0",
         "@types/sanitize-html": "^2.11.0",
         "@typescript-eslint/eslint-plugin": "^5.34.0",
         "@typescript-eslint/parser": "^5.62.0",


### PR DESCRIPTION
## Problem
- Node 18 is at EOL.

## Solution
- Update node version from 18 to 24.
<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
