### PR TITLE
fix: correct IME composition handling with Shift+Enter

### DIFF
--- a/src/components/chat-item/chat-prompt-input.ts
+++ b/src/components/chat-item/chat-prompt-input.ts
@@ -417,8 +417,7 @@ export class ChatPromptInput {
           this.clearTextArea(true);
         }
       } else if (e.key === KeyMap.ENTER &&
-        ((!e.isComposing && !e.shiftKey && !e.ctrlKey) ||
-        (e.isComposing && (e.shiftKey)))) {
+        !e.isComposing && !e.shiftKey && !e.ctrlKey) {
         cancelEvent(e);
         this.sendPrompt();
       } else if (


### PR DESCRIPTION
## Problem
When using IME (CJK), pressing Shift+Enter during character composition incorrectly triggers form submission along with line break insertion.

https://github.com/user-attachments/assets/556fd22e-a859-4276-a9e5-a2137b13807d

https://github.com/user-attachments/assets/9b260def-6faa-45db-af4f-dbdbca72e548


## Solution

Modified the Enter key handler to ignore all keyboard events during IME composition (`e.isComposing === true`), allowing the browser to handle IME input naturally



https://github.com/user-attachments/assets/00fcb2bf-0f99-48f2-ab93-a36189f5d22f


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
