### PR TITLE
feat: add tooltip to select dropdown

### DIFF
--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -309,18 +309,22 @@ export const mynahUIDefaults: Partial<MynahUITabStoreTab> = {
                 id: 'model-select',
                 mandatory: true,
                 hideMandatoryIcon: true,
+                showDescriptionAsTooltip: true,
                 options: [
                     {
                         label: 'Fast',
-                        value: 'fast'
+                        value: 'fast',
+                        description: 'Quick responses with good accuracy'
                     },
                     {
                         label: 'Fast 2.0 (Exp.)',
-                        value: 'fast-2-experimental'
+                        value: 'fast-2-experimental',
+                        description: 'Experimental faster model with enhanced capabilities'
                     },
                     {
                         label: 'Decisive',
-                        value: 'decisive'
+                        value: 'decisive',
+                        description: 'More thorough analysis with detailed responses'
                     },
                 ]
             }

--- a/src/components/chat-item/chat-item-form-items.ts
+++ b/src/components/chat-item/chat-item-form-items.ts
@@ -117,6 +117,7 @@ export class ChatItemFormItemsWrapper {
               optional: chatItemOption.mandatory !== true,
               placeholder: chatItemOption.placeholder ?? Config.getInstance().config.texts.pleaseSelect,
               tooltip: chatItemOption.selectTooltip ?? '',
+              showDescriptionAsTooltip: chatItemOption.showDescriptionAsTooltip,
               ...(this.getHandlers(chatItemOption))
             });
             if (chatItemOption.disabled === true) {

--- a/src/components/form-items/select.ts
+++ b/src/components/form-items/select.ts
@@ -36,6 +36,7 @@ export interface SelectProps {
   wrapperTestId?: string;
   optionTestId?: string;
   tooltip?: string;
+  showDescriptionAsTooltip?: boolean;
 }
 
 export abstract class SelectAbstract {
@@ -97,8 +98,8 @@ export class SelectInternal {
             ]
           };
 
-          // Add disabled description option if description exists
-          if (option.description != null && option.description.trim() !== '') {
+          // Add disabled description option if description exists and not using tooltip
+          if (props.showDescriptionAsTooltip !== true && option.description != null && option.description.trim() !== '') {
             return [
               mainOption,
               {
@@ -149,13 +150,18 @@ export class SelectInternal {
       ]
     });
 
-    // Add tooltip functionality if tooltip is provided
-    if (props.tooltip != null && props.tooltip.trim() !== '') {
+    // Add tooltip functionality
+    this.setupTooltip();
+  }
+
+  private readonly setupTooltip = (): void => {
+    if (this.props.showDescriptionAsTooltip === true) {
       this.selectContainer.update({
         events: {
           mouseenter: () => {
-            if (props.tooltip != null && props.tooltip.trim() !== '') {
-              this.showTooltip(props.tooltip);
+            const currentTooltip = this.getCurrentTooltip();
+            if (currentTooltip != null && currentTooltip.trim() !== '') {
+              this.showTooltip(currentTooltip);
             }
           },
           mouseleave: () => {
@@ -164,7 +170,18 @@ export class SelectInternal {
         }
       });
     }
-  }
+  };
+
+  private readonly getCurrentTooltip = (): string => {
+    const currentValue = this.selectElement.value;
+    const selectedOption = this.props.options?.find(option => option.value === currentValue);
+
+    // Show label and description for tooltip mode; otherwise use base tooltip
+    if (this.props.showDescriptionAsTooltip === true && selectedOption?.description != null) {
+      return `<strong>${selectedOption.label}</strong><br>${selectedOption.description}`;
+    }
+    return this.props.tooltip ?? '';
+  };
 
   setValue = (value: string): void => {
     this.selectElement.value = value;

--- a/src/static.ts
+++ b/src/static.ts
@@ -551,6 +551,7 @@ type DropdownFormItem = BaseFormItem & {
   }>;
   disabled?: boolean;
   selectTooltip?: string;
+  showDescriptionAsTooltip?: boolean;
 };
 
 type Stars = BaseFormItem & {


### PR DESCRIPTION
## Problem
We would like to have a tooltip when hovering over select dropdown

## Solution
Add tooltip when hovering over select dropdown. This only affects select dropdowns with `showDescriptionAsTooltip: true`

## Testing
In this recording, the model selection dropdown has `showDescriptionAsTooltip: true`. We can see that the MCP dropdown still maintains its existing functionality with having the descriptions in the actual dropdown, and not a tooltip

https://github.com/user-attachments/assets/cbe1e219-125c-425f-b4de-5b85ea52e423

<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory
    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
