### PR TITLE
fix: edit tooltip to select dropdown

### DIFF
--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -309,7 +309,6 @@ export const mynahUIDefaults: Partial<MynahUITabStoreTab> = {
                 id: 'model-select',
                 mandatory: true,
                 hideMandatoryIcon: true,
-                showDescriptionAsTooltip: true,
                 options: [
                     {
                         label: 'Fast',

--- a/src/components/chat-item/chat-item-form-items.ts
+++ b/src/components/chat-item/chat-item-form-items.ts
@@ -117,7 +117,6 @@ export class ChatItemFormItemsWrapper {
               optional: chatItemOption.mandatory !== true,
               placeholder: chatItemOption.placeholder ?? Config.getInstance().config.texts.pleaseSelect,
               tooltip: chatItemOption.selectTooltip ?? '',
-              showDescriptionAsTooltip: chatItemOption.showDescriptionAsTooltip,
               ...(this.getHandlers(chatItemOption))
             });
             if (chatItemOption.disabled === true) {

--- a/src/static.ts
+++ b/src/static.ts
@@ -551,7 +551,6 @@ type DropdownFormItem = BaseFormItem & {
   }>;
   disabled?: boolean;
   selectTooltip?: string;
-  showDescriptionAsTooltip?: boolean;
 };
 
 type Stars = BaseFormItem & {


### PR DESCRIPTION
## Problem
- we don't need `showDescriptionAsTooltip` field


## Solution
- remove `showDescriptionAsTooltip` field
- fix tooltip so it can work on both VSC and JB

## Testing
VSC and JB

https://github.com/user-attachments/assets/4145c232-a873-47ef-8b45-686bc9c93e05

https://github.com/user-attachments/assets/32e8c633-14b9-4685-8e31-82b9dfe7fd2c

https://github.com/user-attachments/assets/0b781b91-e871-45da-8d26-5c0f15962a79



<!---
    REMINDER:
    - Read contributing and developer guidelines first.
    - Check your changes are not breaking anything on current VSCode and JetBrains extensions
    - Add or update the documentation if applicable, this is mandatory











    - Put screenshots if possible
-->

## Tests
- [ ] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
