### PR TITLE
feat: add centered layout and tip card

### DIFF
--- a/example/src/commands.ts
+++ b/example/src/commands.ts
@@ -28,5 +28,11 @@ export enum Commands {
     CLEAR_CONTEXT_ITEMS = '/clear-context-items',
     CLEAR_LOGS = '/clear-logs',
     SHOW_CUSTOM_FORM = '/show-custom-form',
-    VOTE = '/vote'
+    VOTE = '/vote',
+
+    // Tab header introduction examples
+    OPEN_TAB_HEADER_CENTERED = '/tab-header-centered',
+    OPEN_TAB_HEADER_WITH_TIP = '/tab-header-with-tip',
+    OPEN_WELCOME_INTRO_TAB = '/welcome-intro',
+    OPEN_NO_ICON_CENTERED_TAB = '/tab-header-no-icon-centered',
 }

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -245,6 +245,35 @@ export const QuickActionCommands: QuickActionCommandGroup[] = [
         ],
     },
     {
+        groupName: 'Examples of **tab header introductions**',
+        commands: [
+            {
+                command: Commands.OPEN_TAB_HEADER_CENTERED,
+                icon: MynahIcons.Q,
+                description:
+                    'Opens a new tab whose `tabHeaderDetails` uses the `centered` flag to stack icon over title in a single column.',
+            },
+            {
+                command: Commands.OPEN_TAB_HEADER_WITH_TIP,
+                icon: MynahIcons.MAGIC,
+                description:
+                    'Opens a new tab whose `tabHeaderDetails` uses the new `tip` field alongside the default left-aligned layout.',
+            },
+            {
+                command: Commands.OPEN_WELCOME_INTRO_TAB,
+                icon: MynahIcons.STAR,
+                description:
+                    'Opens an Amazon Q welcome splash that combines `centered`, `tip`, and `description` entirely via `tabHeaderDetails`.',
+            },
+            {
+                command: Commands.OPEN_NO_ICON_CENTERED_TAB,
+                icon: MynahIcons.LIGHT_BULB,
+                description:
+                    'Opens a centered welcome splash without an icon to confirm `icon` is optional in `tabHeaderDetails`.',
+            },
+        ],
+    },
+    {
         groupName: 'Examples of **system wide components**',
         commands: [
             {

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -17,7 +17,8 @@ import {
     QuickActionCommand,
     ChatItemButton,
     CustomQuickActionCommand,
-    DropdownListOption
+    DropdownListOption,
+    MynahUITabStoreTab
 } from '@aws/mynah-ui';
 import { mcpButton, mynahUIDefaults, promptTopBarTitle, rulesButton, tabbarButtons } from './config';
 import { Log, LogClear } from './logger';
@@ -43,6 +44,10 @@ import {
     exploreTabData,
     qAgentQuickActions,
     welcomeScreenTabData,
+    centeredTabHeaderTabData,
+    tipTabHeaderTabData,
+    welcomeIntroTabData,
+    noIconCenteredTabHeaderTabData,
     exampleConfirmationButtons,
     exampleButtons,
     exampleStatusButtons,
@@ -60,6 +65,16 @@ import escapeHTML from 'escape-html';
 import './styles/styles.scss';
 import { ThemeBuilder } from './theme-builder/theme-builder';
 import { Commands } from './commands';
+
+// Dispatch map for tab header introduction examples. Keeps the switch
+// in onQuickActionCommandGroupActionClick a single case instead of one
+// branch per command.
+const tabHeaderIntroExamples: Partial<Record<Commands, MynahUITabStoreTab>> = {
+    [Commands.OPEN_TAB_HEADER_CENTERED]: centeredTabHeaderTabData,
+    [Commands.OPEN_TAB_HEADER_WITH_TIP]: tipTabHeaderTabData,
+    [Commands.OPEN_WELCOME_INTRO_TAB]: welcomeIntroTabData,
+    [Commands.OPEN_NO_ICON_CENTERED_TAB]: noIconCenteredTabHeaderTabData,
+};
 
 export const createMynahUI = (initialData?: MynahUIDataModel): MynahUI => {
     const connector = new Connector();
@@ -1783,6 +1798,12 @@ here to see if it gets cut off properly as expected, with an ellipsis through cs
                 case Commands.BORDERED_CARDS:
                     mynahUI.addChatItem(tabId, exampleBorderedCard());
                     mynahUI.addChatItem(tabId, defaultFollowUps);
+                    break;
+                case Commands.OPEN_TAB_HEADER_CENTERED:
+                case Commands.OPEN_TAB_HEADER_WITH_TIP:
+                case Commands.OPEN_WELCOME_INTRO_TAB:
+                case Commands.OPEN_NO_ICON_CENTERED_TAB:
+                    mynahUI.updateStore('', tabHeaderIntroExamples[prompt.command as Commands]?.store ?? {});
                     break;
                 case Commands.CONFIRMATION_BUTTONS:
                     mynahUI.addChatItem(tabId, exampleConfirmationButtons);

--- a/example/src/samples/sample-data.ts
+++ b/example/src/samples/sample-data.ts
@@ -2654,3 +2654,103 @@ export const sampleRulesList: DetailedList = {selectable: 'clickable', list: [{c
     description: 'README',actions: [{ id: 'README.md', icon: MynahIcons.OK, status: 'clear' }]}]}, 
     {groupName: '.amazonq/rules', childrenIndented: true, icon: MynahIcons.FOLDER , actions: [{ id: 'java-expert.md', icon: MynahIcons.OK, status: 'clear' }], children: [{id: 'java-expert.md', icon: MynahIcons.CHECK_LIST, 
     description: 'java-expert',actions: [{ id: 'java-expert.md', icon: MynahIcons.OK, status: 'clear' }]}]}]}
+
+
+// -----------------------------------------------------------------------------
+// Tab header introduction examples (TitleDescriptionWithIcon: centered + tip)
+// -----------------------------------------------------------------------------
+
+/**
+ * Minimal centered tab header. Shows the new `centered` flag stacking icon
+ * over title in a single column. No tip, no description.
+ */
+export const centeredTabHeaderTabData: MynahUITabStoreTab = {
+    isSelected: false,
+    store: {
+        tabTitle: 'Centered header',
+        tabBackground: false,
+        compactMode: false,
+        promptInputPlaceholder: 'Type your question',
+        chatItems: [],
+        tabHeaderDetails: {
+            icon: MynahIcons.Q,
+            title: 'Amazon Q',
+            centered: true,
+        },
+    },
+};
+
+/**
+ * Default (left-aligned) tab header layout extended with the new `tip` card.
+ * Demonstrates that the tip card renders alongside the existing
+ * `icon | title` two-column grid without any layout regression.
+ */
+export const tipTabHeaderTabData: MynahUITabStoreTab = {
+    isSelected: false,
+    store: {
+        tabTitle: 'Tip header',
+        tabBackground: false,
+        compactMode: false,
+        promptInputPlaceholder: 'Type your question',
+        chatItems: [],
+        tabHeaderDetails: {
+            icon: MynahIcons.MAGIC,
+            title: 'Workspace context',
+            tip: {
+                title: 'Did you know?',
+                body: 'Pinned context is always included in future chat messages.',
+            },
+            description: 'Type @ to attach files or saved prompts to your next message.',
+        },
+    },
+};
+
+/**
+ * Centered welcome splash without an icon. Confirms `icon` stays optional
+ * and the centered layout still applies for icon-less consumers.
+ */
+export const noIconCenteredTabHeaderTabData: MynahUITabStoreTab = {
+    isSelected: false,
+    store: {
+        tabTitle: 'No-icon centered',
+        tabBackground: false,
+        compactMode: false,
+        promptInputPlaceholder: 'Type your question',
+        chatItems: [],
+        tabHeaderDetails: {
+            title: 'Amazon Q',
+            tip: {
+                title: 'Did you know?',
+                body: 'You can omit the icon and still use the centered layout.',
+            },
+            description: 'Type a question or use `/` to see quick actions.',
+            centered: true,
+        },
+    },
+};
+
+/**
+ * Full Amazon Q welcome introduction surface. Combines the new `centered`
+ * layout with `tip` and `description` so the entire splash is owned by
+ * `tabHeaderDetails` (the host only passes data, mynah-ui handles styling).
+ */
+export const welcomeIntroTabData: MynahUITabStoreTab = {
+    isSelected: false,
+    store: {
+        tabTitle: 'Welcome intro',
+        tabBackground: false,
+        compactMode: false,
+        promptInputPlaceholder: 'Ask a question. Use @ to add context, / for quick actions',
+        chatItems: [],
+        tabHeaderDetails: {
+            icon: MynahIcons.Q,
+            title: 'Amazon Q',
+            tip: {
+                title: 'Did you know?',
+                body: 'Pinned context is always included in future chat messages.',
+            },
+            description: 'Select code & ask me to explain, debug or optimize it, or type `/` for quick actions.',
+            centered: true,
+        },
+    },
+};

--- a/src/__test__/components/title-description-with-icon.spec.ts
+++ b/src/__test__/components/title-description-with-icon.spec.ts
@@ -1,0 +1,103 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TitleDescriptionWithIcon } from '../../components/title-description-with-icon';
+import { MynahIcons } from '../../components/icon';
+
+describe('TitleDescriptionWithIcon Component', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('Legacy layout (no centered prop)', () => {
+    it('renders with the original wrapper class only when an icon is provided or centered is true', () => {
+      const withIcon = new TitleDescriptionWithIcon({
+        icon: MynahIcons.Q,
+        title: 'Hi',
+      });
+      expect(withIcon.render.classList.contains('mynah-ui-title-description-icon-wrapper')).toBe(true);
+      expect(withIcon.render.classList.contains('mynah-ui-title-description-icon-wrapper-centered')).toBe(false);
+
+      const centeredOnly = new TitleDescriptionWithIcon({ title: 'Hi', centered: true });
+      expect(centeredOnly.render.classList.contains('mynah-ui-title-description-icon-wrapper')).toBe(true);
+      expect(centeredOnly.render.classList.contains('mynah-ui-title-description-icon-wrapper-centered')).toBe(true);
+
+      const plain = new TitleDescriptionWithIcon({ title: 'Hi' });
+      expect(plain.render.classList.contains('mynah-ui-title-description-icon-wrapper')).toBe(false);
+    });
+
+    it('does not render a tip block when tip prop is omitted', () => {
+      const component = new TitleDescriptionWithIcon({
+        icon: MynahIcons.Q,
+        title: 'Title',
+        description: 'Description',
+      });
+      expect(component.render.querySelector('.mynah-ui-title-description-icon-tip')).toBeNull();
+    });
+  });
+
+  describe('Centered layout', () => {
+    it('adds the centered modifier class when centered is true', () => {
+      const component = new TitleDescriptionWithIcon({
+        icon: MynahIcons.Q,
+        title: 'Amazon Q',
+        centered: true,
+      });
+      expect(component.render.classList.contains('mynah-ui-title-description-icon-wrapper-centered')).toBe(true);
+    });
+
+    it('omits the centered modifier when centered is false or unset', () => {
+      const a = new TitleDescriptionWithIcon({ icon: MynahIcons.Q, title: 'Amazon Q' });
+      const b = new TitleDescriptionWithIcon({ icon: MynahIcons.Q, title: 'Amazon Q', centered: false });
+      expect(a.render.classList.contains('mynah-ui-title-description-icon-wrapper-centered')).toBe(false);
+      expect(b.render.classList.contains('mynah-ui-title-description-icon-wrapper-centered')).toBe(false);
+    });
+  });
+
+  describe('Tip card', () => {
+    it('renders a tip block with title and body when tip is provided', () => {
+      const component = new TitleDescriptionWithIcon({
+        icon: MynahIcons.Q,
+        title: 'Amazon Q',
+        tip: { title: 'Did you know?', body: 'Pinned context is always included' },
+        description: 'Select code & ask',
+        centered: true,
+      });
+      const tip = component.render.querySelector('.mynah-ui-title-description-icon-tip');
+      expect(tip).not.toBeNull();
+      expect(tip?.querySelector('.mynah-ui-title-description-icon-tip-title')?.textContent).toBe('Did you know?');
+      expect(tip?.querySelector('.mynah-ui-title-description-icon-tip-body')?.textContent).toBe('Pinned context is always included');
+    });
+
+    it('renders only the parts of the tip that are provided', () => {
+      const onlyBody = new TitleDescriptionWithIcon({
+        title: 'Amazon Q',
+        tip: { body: 'Just a body' },
+      });
+      expect(onlyBody.render.querySelector('.mynah-ui-title-description-icon-tip-title')).toBeNull();
+      expect(onlyBody.render.querySelector('.mynah-ui-title-description-icon-tip-body')?.textContent).toBe('Just a body');
+    });
+
+    it('places the tip between title and description in the DOM', () => {
+      const component = new TitleDescriptionWithIcon({
+        icon: MynahIcons.Q,
+        title: 'Amazon Q',
+        tip: { title: 'Did you know?', body: 'A tip' },
+        description: 'Select code & ask',
+      });
+      const children = Array.from(component.render.children);
+      const titleIndex = children.findIndex(c => c.classList.contains('mynah-ui-title-description-icon-title'));
+      const tipIndex = children.findIndex(c => c.classList.contains('mynah-ui-title-description-icon-tip'));
+      const descIndex = children.findIndex(c => c.classList.contains('mynah-ui-title-description-icon-description'));
+      expect(titleIndex).toBeGreaterThanOrEqual(0);
+      expect(tipIndex).toBeGreaterThan(titleIndex);
+      expect(descIndex).toBeGreaterThan(tipIndex);
+    });
+  });
+});

--- a/src/components/title-description-with-icon.ts
+++ b/src/components/title-description-with-icon.ts
@@ -8,10 +8,26 @@ import { DomBuilder, DomBuilderObject, ExtendedHTMLElement } from '../helper/dom
 import { StyleLoader } from '../helper/style-loader';
 import { Icon, MynahIcons, MynahIconsType } from './icon';
 
+export interface TitleDescriptionWithIconTip {
+  title?: string | ExtendedHTMLElement | HTMLElement | DomBuilderObject;
+  body?: string | ExtendedHTMLElement | HTMLElement | DomBuilderObject;
+}
+
 interface TitleDescriptionWithIconProps {
   title?: string | ExtendedHTMLElement | HTMLElement | DomBuilderObject;
   description?: string | ExtendedHTMLElement | HTMLElement | DomBuilderObject;
   icon?: MynahIcons | MynahIconsType;
+  /**
+   * Optional tip card rendered between the title and the description.
+   * Useful for "Did you know?"-style introductions on welcome surfaces.
+   */
+  tip?: TitleDescriptionWithIconTip;
+  /**
+   * When true, lays out icon, title, tip and description in a single
+   * centered column instead of the default `icon | title` two-column grid.
+   * Existing consumers get the original layout when this is not set.
+   */
+  centered?: boolean;
   testId?: string;
   classNames?: string[];
 }
@@ -24,9 +40,15 @@ export class TitleDescriptionWithIcon {
     this.render = DomBuilder.getInstance().build({
       type: 'div',
       testId: props.testId,
-      // Apply icon wrapper styles only if icon is provided
+      // Apply the wrapper styles when the layout depends on them: when an
+      // icon needs to be positioned next to the title, or when the centered
+      // variant is requested. Existing callers that pass only a title or
+      // description without an icon keep their original simple <div> output.
       classNames: [
-        ...(this.props.icon !== undefined ? [ 'mynah-ui-title-description-icon-wrapper' ] : []),
+        ...(this.props.icon !== undefined || this.props.centered === true
+          ? [ 'mynah-ui-title-description-icon-wrapper' ]
+          : []),
+        ...(this.props.centered === true ? [ 'mynah-ui-title-description-icon-wrapper-centered' ] : []),
         ...(this.props.classNames ?? [])
       ],
       children: [
@@ -48,6 +70,31 @@ export class TitleDescriptionWithIcon {
               children: [ this.props.title ]
             } ]
           : []),
+        ...(this.props.tip !== undefined
+          ? [ {
+              type: 'div',
+              testId: `${props.testId ?? ''}-tip`,
+              classNames: [ 'mynah-ui-title-description-icon-tip' ],
+              children: [
+                ...(this.props.tip.title !== undefined
+                  ? [ {
+                      type: 'div',
+                      testId: `${props.testId ?? ''}-tip-title`,
+                      classNames: [ 'mynah-ui-title-description-icon-tip-title' ],
+                      children: [ this.props.tip.title ]
+                    } ]
+                  : []),
+                ...(this.props.tip.body !== undefined
+                  ? [ {
+                      type: 'div',
+                      testId: `${props.testId ?? ''}-tip-body`,
+                      classNames: [ 'mynah-ui-title-description-icon-tip-body' ],
+                      children: [ this.props.tip.body ]
+                    } ]
+                  : [])
+              ]
+            } ]
+          : []),
         ...(this.props.description !== undefined
           ? [ {
               type: 'div',
@@ -57,6 +104,6 @@ export class TitleDescriptionWithIcon {
             } ]
           : [])
       ]
-    }); ;
+    });
   }
 }

--- a/src/static.ts
+++ b/src/static.ts
@@ -752,6 +752,21 @@ export interface TabHeaderDetails {
   icon?: MynahIcons | MynahIconsType;
   title?: string;
   description?: string;
+  /**
+   * Optional tip card rendered between the title and the description.
+   * Useful for "Did you know?"-style introductions on welcome surfaces.
+   */
+  tip?: {
+    title?: string;
+    body?: string;
+  };
+  /**
+   * When true, the tab header is rendered in a centered single-column
+   * layout (icon stacked above title, tip and description). Defaults to
+   * false to preserve the existing two-column left-aligned layout for
+   * current consumers.
+   */
+  centered?: boolean;
 }
 
 export interface CodeBlockAction {

--- a/src/styles/components/_title-description-icon.scss
+++ b/src/styles/components/_title-description-icon.scss
@@ -30,4 +30,69 @@
     > .mynah-ui-title-description-icon-description {
         grid-area: description;
     }
+
+    // Default (left-aligned) layout extended with the optional tip card.
+    // The tip spans the full width of the wrapper and sits between the
+    // title row and the description row.
+    &:has(> .mynah-ui-title-description-icon-tip) {
+        grid-template-areas:
+            'icon title'
+            'tip  tip'
+            '.    description';
+    }
+    > .mynah-ui-title-description-icon-tip {
+        grid-area: tip;
+    }
+}
+
+// Centered variant: stacks icon, title, optional tip, and description in a
+// single centered column. Used for welcome / introduction surfaces.
+.mynah-ui-title-description-icon-wrapper.mynah-ui-title-description-icon-wrapper-centered {
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    row-gap: var(--mynah-sizing-2);
+
+    > .mynah-ui-title-description-icon-icon,
+    > .mynah-ui-title-description-icon-title,
+    > .mynah-ui-title-description-icon-description {
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        width: 100%;
+    }
+
+    // Description is meant to be a helper line, not a heading. Reset it to
+    // the default body size so the surrounding chat-wrapper rule that
+    // upsizes title and description for tab headers does not apply here.
+    > .mynah-ui-title-description-icon-description {
+        font-size: var(--mynah-font-size-medium);
+        font-weight: normal;
+    }
+}
+
+// Optional inline tip card (e.g. "Did you know?"). Picks up theme colors
+// via existing CSS variables so it stays light/dark theme aware.
+.mynah-ui-title-description-icon-wrapper > .mynah-ui-title-description-icon-tip {
+    box-sizing: border-box;
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: var(--mynah-sizing-3) var(--mynah-sizing-4);
+    border-radius: var(--mynah-card-radius);
+    background-color: var(--mynah-color-deep);
+    border: var(--mynah-border-width) solid var(--mynah-color-border-default);
+    color: var(--mynah-color-text-default);
+
+    > .mynah-ui-title-description-icon-tip-title {
+        font-weight: bold;
+        margin-bottom: var(--mynah-sizing-half);
+    }
+    > .mynah-ui-title-description-icon-tip-body {
+        font-size: var(--mynah-font-size-medium);
+    }
 }

--- a/src/styles/components/chat/_chat-wrapper.scss
+++ b/src/styles/components/chat/_chat-wrapper.scss
@@ -98,6 +98,22 @@
             padding-top: var(--mynah-sizing-1);
             padding-bottom: var(--mynah-sizing-12);
         }
+        // When the tab header is rendered in the centered (welcome / intro)
+        // layout, restore the default chat-wrapper flow so the prompt input
+        // stays at the bottom and the chat items container can grow normally.
+        // Existing non-compact tab headers (e.g. account details, explore)
+        // are unaffected because they do not opt into the centered class.
+        &:has(> .mynah-ui-tab-header-details.mynah-ui-title-description-icon-wrapper-centered) {
+            > .mynah-chat-wrapper-footer-spacer {
+                flex-grow: 0 !important;
+            }
+            > .mynah-chat-wrapper-header-spacer {
+                flex-grow: 0 !important;
+            }
+            > .mynah-chat-items-container {
+                flex-grow: 1;
+            }
+        }
         > .mynah-chat-items-container > .mynah-chat-items-conversation-container {
             > .mynah-chat-item-card {
                 &:not(.mynah-chat-item-prompt, .mynah-chat-item-system-prompt) {


### PR DESCRIPTION
## Problem
`TitleDescriptionWithIcon` and `TabHeaderDetails` only support a single
left-aligned, two-column layout (`icon | title` with the description on a
second row). Welcome / introduction surfaces in the host IDE plugins want a
different shape:

- A centered, single-column layout where the icon stacks above the title.
- An inline "Did you know?"-style tip card sitting between the title and
  the description.

Today the plugin teams have to render these surfaces themselves with custom
DOM and styles, which means the host owns layout decisions that should live
in mynah-ui.

## Solution

Extend `TitleDescriptionWithIcon` and `TabHeaderDetails` with two optional,
opt-in fields. Existing consumers are unaffected when neither is set.

**`centered: boolean`**
- Stacks icon, title, tip and description in a single centered column.
- Adds a `mynah-ui-title-description-icon-wrapper-centered` modifier class
  that styles can target.
- The wrapper class is now applied when `centered` is true even without an
  icon (otherwise centered-without-icon would lose all wrapper styles).
- Chat-wrapper layout is adjusted via `:has(...)` so the prompt input stays
  pinned to the bottom and the chat-items container can grow when a tab
  header opts into the centered variant. Non-centered tab headers
  (account details, explore, etc.) are unaffected.

**`tip: { title?, body? }`**
- Optional inline card rendered between the title and the description.
- Picks up theme colors via existing CSS variables, so it stays light/dark
  theme aware.
- The default grid template is extended via `:has(> .tip)` to add a row
  when a tip is present, keeping the original two-column layout intact
  when it is not.

### Examples

Four example tabs are added to exercise the new fields, wired through a
small dispatch map in `main.ts` (avoids four copy-paste switch branches):

| Slash command | Demonstrates |
|---|---|
| `/tab-header-centered` | `centered` flag, no tip, no description |
| `/tab-header-with-tip` | Default left-aligned layout extended with `tip` |
| `/welcome-intro` | Full Amazon Q welcome splash: `centered` + `tip` + `description` |
| `/tab-header-no-icon-centered` | Centered layout without an icon (confirms `icon` is optional) |

### Tests

Adds `src/__test__/components/title-description-with-icon.spec.ts` (7 tests)
covering:

- Wrapper class is applied when icon is present, when centered is true, and
  not applied otherwise (preserves the legacy plain-`<div>` output).
- `-centered` modifier class is gated on `centered === true`.
- Tip block renders when `tip` is provided, with conditional title/body.
- Tip is positioned between title and description in the DOM.

### Backward compatibility

- Both new fields are optional; existing call sites render unchanged.
- The public `TabHeaderDetails.tip` only accepts plain strings; the
  internal component accepts richer types so chat content can still pass
  `ExtendedHTMLElement` / `DomBuilderObject` if needed later.
- The default grid template only changes when a tip is present
  (`:has(> .tip)` selector), so headers without a tip render exactly as
  before.
  

### Screenshots

<img width="1087" height="1176" alt="image" src="https://github.com/user-attachments/assets/4e38f972-e46c-4e99-b117-b988bc0142eb" />


<img width="3024" height="1772" alt="image" src="https://github.com/user-attachments/assets/6710a920-35f4-4a37-a30a-aa31547baf60" />


## Tests
- [x] I have tested this change on VSCode
- [ ] I have tested this change on JetBrains
- [ ] I have added/updated the documentation (if applicable)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
