### PR TITLE
fix: enable horizontal scrollbar in code blocks

### DIFF
--- a/src/styles/components/_main-container.scss
+++ b/src/styles/components/_main-container.scss
@@ -55,8 +55,7 @@ body.mynah-ui-root {
         height: 2px;
         opacity: 0.25;
         &:horizontal {
-            width: 0px;
-            height: 0px;
+            height: 4px;
         }
     }
 

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -126,6 +126,7 @@
         padding: var(--mynah-sizing-2);
         position: relative;
         margin: 0;
+        min-width: 0;
         overflow-x: auto;
         overflow-y: scroll;
         box-sizing: border-box;

--- a/ui-tests/__test__/flows/quick-action-commands-header.ts
+++ b/ui-tests/__test__/flows/quick-action-commands-header.ts
@@ -140,7 +140,7 @@ export const verifyQuickActionCommandsHeaderStatusVariations = async (page: Page
     const hasStatus = await headerElement.evaluate((el, className) =>
       el.classList.contains(className), statusClass
     );
-    if (hasStatus) {
+    if (hasStatus === true) {
       foundStatusClass = true;
       console.log(`Found status class: ${statusClass}`);
       break;


### PR DESCRIPTION
## Problem

Code blocks in the chat window have no horizontal scrollbar. Long lines (e.g. multi-flag CLI commands, wide table output) are truncated at the panel edge with no way to view the hidden content.

## Solution

Two CSS issues compound to make horizontal scrolling impossible:

1. **Webkit scrollbar rule hides horizontal tracks:** `_main-container.scss` set `::-webkit-scrollbar:horizontal { width: 0px; height: 0px; }` which makes the scrollbar invisible in webkit-based browsers (Chrome, Edge, and the JCEF browser embedded in JetBrains IDEs). Fixed by restoring a visible `height: 4px` track.

2. **Flex-child overflow:** The `pre` element inside `.mynah-syntax-highlighter` (a flex-column container with `max-width: 100%`) lacked `min-width: 0`, which is the classic fix to prevent flex children from expanding beyond their parent. Without it, the `pre` pushes beyond the parent's constraint instead of scrolling internally. Added `min-width: 0` so `overflow-x: auto` on `pre` works as intended.

### What changes for users

| Scenario | Before | After |
|---|---|---|
| Long code line in response | Truncated, no scroll | Horizontal scrollbar appears, user can scroll |
| Short code line in response | No scrollbar | No scrollbar (unchanged, `overflow-x: auto` only shows when needed) |
| Narrow viewport (< breakpoint) | `pre-wrap` wraps lines | Same (responsive behavior unchanged) |

## Testing

- `npm run build` compiles without errors
- Visual verification: the `pre` element with long content now shows a thin (4px) horizontal scrollbar track in webkit browsers
- Responsive `pre-wrap` at narrow viewport widths still works (the `@media (max-width)` rules are untouched)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.