### PR TITLE
fix: form item tooltip persists over chat after clicking a toggle

### DIFF
--- a/src/components/__test__/chat-item/chat-item-form-items.spec.ts
+++ b/src/components/__test__/chat-item/chat-item-form-items.spec.ts
@@ -1,6 +1,20 @@
 import { ChatItemFormItemsWrapper } from '../../chat-item/chat-item-form-items';
 import { ChatItem, ChatItemType } from '../../../static';
 
+// Mock the overlay so we can observe when the tooltip is shown (constructed) and
+// hidden (close() called), without depending on real positioning/rendering.
+jest.mock('../../overlay', () => ({
+  Overlay: jest.fn().mockImplementation(() => ({
+    close: jest.fn()
+  })),
+  OverlayHorizontalDirection: {
+    START_TO_RIGHT: 'start-to-right'
+  },
+  OverlayVerticalDirection: {
+    TO_TOP: 'to-top'
+  }
+}));
+
 describe('ChatItemFormItemsWrapper', () => {
   it('should render form items wrapper', () => {
     const wrapper = new ChatItemFormItemsWrapper({
@@ -120,5 +134,80 @@ describe('ChatItemFormItemsWrapper', () => {
 
     const textInput = wrapper.render.querySelector('input[type="text"]');
     expect(textInput?.hasAttribute('disabled')).toBe(false);
+  });
+
+  describe('form item tooltip lifecycle', () => {
+    const buildSwitchWrapper = (): ChatItemFormItemsWrapper => {
+      const chatItem: ChatItem = {
+        type: ChatItemType.PROMPT,
+        formItems: [
+          {
+            id: 'agentic-toggle',
+            type: 'switch',
+            title: 'Agentic coding',
+            value: 'true',
+            tooltip: 'Turn OFF agentic coding',
+            alternateTooltip: 'Turn ON agentic coding'
+          }
+        ]
+      };
+      return new ChatItemFormItemsWrapper({ tabId: 'test-tab', chatItem });
+    };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      const { Overlay } = jest.requireMock('../../overlay');
+      (Overlay as jest.Mock).mockClear();
+      document.body.innerHTML = '';
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      document.body.innerHTML = '';
+    });
+
+    it('should show the tooltip on hover after the delay', () => {
+      const wrapper = buildSwitchWrapper();
+      document.body.appendChild(wrapper.render);
+      const switchEl = wrapper.render.querySelector('.mynah-form-input-wrapper') as HTMLElement;
+      expect(switchEl).not.toBeNull();
+
+      switchEl.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      jest.advanceTimersByTime(350);
+
+      const { Overlay } = jest.requireMock('../../overlay');
+      expect(Overlay).toHaveBeenCalledTimes(1);
+    });
+
+    it('should dismiss the tooltip when the control is clicked (so it cannot block the chat after toggling)', () => {
+      const wrapper = buildSwitchWrapper();
+      document.body.appendChild(wrapper.render);
+      const switchEl = wrapper.render.querySelector('.mynah-form-input-wrapper') as HTMLElement;
+
+      switchEl.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      jest.advanceTimersByTime(350);
+
+      const { Overlay } = jest.requireMock('../../overlay');
+      const overlayInstance = (Overlay as jest.Mock).mock.results[0].value;
+
+      switchEl.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(overlayInstance.close).toHaveBeenCalled();
+    });
+
+    it('should cancel a pending tooltip when the control is clicked before it appears', () => {
+      const wrapper = buildSwitchWrapper();
+      document.body.appendChild(wrapper.render);
+      const switchEl = wrapper.render.querySelector('.mynah-form-input-wrapper') as HTMLElement;
+
+      // Hover starts the show timer, but the user clicks before the delay elapses.
+      switchEl.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      switchEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      switchEl.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      jest.advanceTimersByTime(350);
+
+      // The overlay must never be created, otherwise it would linger over the chat.
+      const { Overlay } = jest.requireMock('../../overlay');
+      expect(Overlay).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/chat-item/chat-item-form-items.ts
+++ b/src/components/chat-item/chat-item-form-items.ts
@@ -291,6 +291,12 @@ export class ChatItemFormItemsWrapper {
                     this.showTooltip(tooltipToShow, chatOption.render);
                   }
                 },
+                // Dismiss the tooltip as soon as the control is activated. Toggling an
+                // option (e.g. a switch) can re-render the prompt input and remove this
+                // element before 'mouseleave' fires, which would otherwise leave the
+                // tooltip overlay orphaned on top of the chat and block interaction.
+                mousedown: this.hideTooltip,
+                click: this.hideTooltip,
                 mouseleave: this.hideTooltip
               }
             });

--- a/ui-tests/__test__/flows/quick-action-commands-header.ts
+++ b/ui-tests/__test__/flows/quick-action-commands-header.ts
@@ -137,9 +137,9 @@ export const verifyQuickActionCommandsHeaderStatusVariations = async (page: Page
   let foundStatusClass = false;
 
   for (const statusClass of statusClasses) {
-    const hasStatus = await headerElement.evaluate((el, className) =>
+    const hasStatus = Boolean(await headerElement.evaluate((el, className) =>
       el.classList.contains(className), statusClass
-    );
+    ));
     if (hasStatus) {
       foundStatusClass = true;
       console.log(`Found status class: ${statusClass}`);


### PR DESCRIPTION
## Summary

A form-item tooltip (for example, the tooltip on a toggle switch such as the agentic-coding mode toggle) could remain on screen after the control was clicked, overlaying the chat and blocking interaction until it was dismissed. This PR makes the tooltip dismiss as soon as the control is activated.

## Problem

Steps that reproduce the issue:

1. Hover over a form-item control that has a tooltip (e.g. a switch) — the tooltip appears.
2. Click the control to toggle it.
3. The tooltip stays visible on top of the chat and cannot be interacted around, making the chat temporarily unusable.

## Root cause

In `src/components/chat-item/chat-item-form-items.ts`, the tooltip was wired to only two events:

```ts
mouseover: (e) => { /* ...show tooltip after a delay... */ },
mouseleave: this.hideTooltip
```

When the control is clicked:

- No handler hid the tooltip on click, and the overlay is created with `closeOnOutsideClick: false`, so clicking does not dismiss it.
- Toggling the control can cause the prompt input to re-render, which removes the control element before `mouseleave` fires. The tooltip `Overlay` is appended to the document body, so it is left orphaned on top of the chat with no element left to trigger `mouseleave`.

## Fix

Dismiss the tooltip when the control is activated by also handling `mousedown` and `click`:

```ts
mouseover: (e) => { /* ...show tooltip after a delay... */ },
mousedown: this.hideTooltip,
click: this.hideTooltip,
mouseleave: this.hideTooltip
```

`hideTooltip` both closes an open tooltip overlay and clears the pending show-timer, so it also prevents a tooltip from appearing after the user has already clicked.

## Testing

- Added unit tests in `src/components/__test__/chat-item/chat-item-form-items.spec.ts`:
  - the tooltip is shown on hover after the delay;
  - the tooltip is dismissed when the control is clicked (so it cannot block the chat after toggling);
  - a pending tooltip is cancelled when the control is clicked before the delay elapses.
- The dismiss/cancel tests were confirmed to fail against the previous implementation and pass with this change.
- Full unit test suite passes (`npx jest`): 72 suites / 845 tests.
- `eslint` and `prettier --check` pass; production build (`npm run build`) succeeds.

## Additional change

- `ui-tests/__test__/flows/quick-action-commands-header.ts`: coerced the result of a Playwright `evaluate` call to a boolean with `Boolean(...)` before using it in a condition. This keeps the value a genuine boolean across toolchains, satisfying `@typescript-eslint/strict-boolean-expressions`, and keeps the repo lint gate green.

## Notes

- Change is limited to tooltip event handling for form items; no public API changes.
