### PR TITLE
fix: render file tree tooltip path as literal text, not markdown

### DIFF
--- a/src/components/__test__/chat-item/chat-item-tree-file.spec.ts
+++ b/src/components/__test__/chat-item/chat-item-tree-file.spec.ts
@@ -1,5 +1,19 @@
 import { ChatItemTreeFile } from '../../chat-item/chat-item-tree-file';
 
+// Mock the overlay so we can capture the tooltip content that gets rendered.
+jest.mock('../../overlay', () => ({
+  Overlay: jest.fn().mockImplementation(() => ({
+    close: jest.fn(),
+  })),
+  OverlayHorizontalDirection: {
+    START_TO_RIGHT: 'start-to-right',
+    CENTER: 'center',
+  },
+  OverlayVerticalDirection: {
+    TO_TOP: 'to-top',
+  },
+}));
+
 describe('ChatItemTreeFile', () => {
   it('should render tree file with basic properties', () => {
     const treeFile = new ChatItemTreeFile({
@@ -7,9 +21,52 @@ describe('ChatItemTreeFile', () => {
       messageId: 'test-message',
       filePath: '/src/test.ts',
       originalFilePath: '/src/test.ts',
-      fileName: 'test.ts'
+      fileName: 'test.ts',
     });
 
     expect(treeFile.render).toBeDefined();
+  });
+
+  describe('tooltip', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      const { Overlay } = jest.requireMock('../../overlay')
+      ;(Overlay as jest.Mock).mockClear();
+      document.body.innerHTML = '';
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      document.body.innerHTML = '';
+    });
+
+    const getTooltipText = (): string => {
+      const { Overlay } = jest.requireMock('../../overlay');
+      expect(Overlay).toHaveBeenCalledTimes(1);
+      const overlayProps = (Overlay as jest.Mock).mock.calls[0][0];
+      return (overlayProps.children[0] as HTMLElement).textContent ?? '';
+    };
+
+    it('shows a Windows file path in the tooltip verbatim (backslashes preserved)', () => {
+      // The backslash before ".gradle" must survive; markdown rendering would drop it.
+      const windowsPath = 'C:\\Users\\discr\\.gradle\\init.gradle';
+      const treeFile = new ChatItemTreeFile({
+        tabId: 'test-tab',
+        messageId: 'test-message',
+        filePath: windowsPath,
+        originalFilePath: windowsPath,
+        fileName: 'init.gradle',
+        details: { description: windowsPath },
+      });
+      document.body.appendChild(treeFile.render);
+
+      treeFile.render.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      jest.advanceTimersByTime(250);
+
+      const text = getTooltipText();
+      expect(text).toContain(windowsPath);
+      // Regression guard: the path must not be collapsed to "discr.gradle".
+      expect(text).not.toContain('discr.gradle\\init.gradle');
+    });
   });
 });

--- a/src/components/chat-item/chat-item-tree-file.ts
+++ b/src/components/chat-item/chat-item-tree-file.ts
@@ -3,11 +3,9 @@ import { MynahUIGlobalEvents, cancelEvent } from '../../helper/events';
 import { FileNodeAction, MynahEventNames, TreeNodeDetails } from '../../static';
 import { Button } from '../button';
 import { Card } from '../card/card';
-import { CardBody } from '../card/card-body';
 import { Icon, MynahIcons, MynahIconsType } from '../icon';
 import { Overlay, OverlayHorizontalDirection, OverlayVerticalDirection } from '../overlay';
 import testIds from '../../helper/test-ids';
-import { parseMarkdown } from '../../helper/marked';
 
 export interface ChatItemTreeFileProps {
   tabId: string;
@@ -54,20 +52,19 @@ export class ChatItemTreeFile {
         mouseover: (e) => {
           cancelEvent(e);
           const textContentSpan: HTMLSpanElement | null = this.render.querySelector('.mynah-chat-item-tree-view-file-item-title-text');
-          let tooltipText;
+          // The file name and path are literal text (e.g. Windows paths such as
+          // C:\Users\me\.gradle\init.gradle). They must not be rendered as markdown,
+          // otherwise sequences like "\." are treated as escape characters and the
+          // backslash is dropped from the displayed path.
+          const tooltipLines: string[] = [];
           if (textContentSpan != null && textContentSpan.offsetWidth < textContentSpan.scrollWidth) {
-            tooltipText = parseMarkdown(this.props.fileName, { includeLineBreaks: true });
+            tooltipLines.push(this.props.fileName);
           }
-          if (this.props.details?.description != null) {
-            if (tooltipText != null) {
-              tooltipText += '\n\n';
-            } else {
-              tooltipText = '';
-            }
-            tooltipText += parseMarkdown(this.props.details?.description ?? '', { includeLineBreaks: true });
+          if (this.props.details?.description != null && this.props.details.description !== '') {
+            tooltipLines.push(this.props.details.description);
           }
-          if (tooltipText != null) {
-            this.showTooltip(tooltipText, undefined, OverlayHorizontalDirection.START_TO_RIGHT, textContentSpan);
+          if (tooltipLines.length > 0) {
+            this.showTooltip(tooltipLines, undefined, OverlayHorizontalDirection.START_TO_RIGHT, textContentSpan);
           }
         },
         mouseleave: this.hideTooltip
@@ -153,8 +150,9 @@ export class ChatItemTreeFile {
     });
   }
 
-  private readonly showTooltip = (content: string, vDir?: OverlayVerticalDirection, hDir?: OverlayHorizontalDirection, elm?: null | HTMLElement | ExtendedHTMLElement): void => {
-    if (content.trim() !== '') {
+  private readonly showTooltip = (lines: string[], vDir?: OverlayVerticalDirection, hDir?: OverlayHorizontalDirection, elm?: null | HTMLElement | ExtendedHTMLElement): void => {
+    const nonEmptyLines = lines.filter((line) => line.trim() !== '');
+    if (nonEmptyLines.length > 0) {
       clearTimeout(this.fileTooltipTimeout);
       this.fileTooltipTimeout = setTimeout(() => {
         clearTimeout(this.fileTooltipTimeout);
@@ -170,11 +168,15 @@ export class ChatItemTreeFile {
           children: [
             new Card({
               border: false,
-              children: [
-                new CardBody({
-                  body: content
-                }).render
-              ]
+              // Render each line as literal text (not markdown) so file paths are
+              // shown verbatim, including backslashes in Windows paths.
+              children: nonEmptyLines.map((line) =>
+                DomBuilder.getInstance().build({
+                  type: 'div',
+                  classNames: [ 'mynah-chat-item-tree-view-file-tooltip-line' ],
+                  children: [ line ],
+                })
+              ),
             }).render
           ],
         });

--- a/ui-tests/__test__/flows/quick-action-commands-header.ts
+++ b/ui-tests/__test__/flows/quick-action-commands-header.ts
@@ -137,9 +137,9 @@ export const verifyQuickActionCommandsHeaderStatusVariations = async (page: Page
   let foundStatusClass = false;
 
   for (const statusClass of statusClasses) {
-    const hasStatus = await headerElement.evaluate((el, className) =>
+    const hasStatus = Boolean(await headerElement.evaluate((el, className) =>
       el.classList.contains(className), statusClass
-    );
+    ));
     if (hasStatus) {
       foundStatusClass = true;
       console.log(`Found status class: ${statusClass}`);


### PR DESCRIPTION
## Problem

File paths shown in the file-tree item tooltip are displayed incorrectly on Windows: the backslash before a dot is dropped. For example `C:\Users\discr\.gradle\init.gradle` is shown as `C:\Users\discr.gradle\init.gradle`, and `...\repo\project\.github\workflows\main.yml` is shown as `...\repo\project.github\workflows\main.yml`.

## Root cause

In `src/components/chat-item/chat-item-tree-file.ts`, the tooltip built its content by running the file name and `details.description` (the full path) through `parseMarkdown(...)`, and then rendered the result through `CardBody`, which parses markdown as well.

A file path is not markdown. Markdown treats a backslash before ASCII punctuation as an escape, so `\.` becomes `.` and the backslash is removed. Backslashes before letters (e.g. `\U`, `\g`) are preserved, which is why only the `\.` segments were affected — exactly matching the reported behavior.

## Fix

Render the tooltip lines (file name and path) as **literal text** instead of markdown:

- The `mouseover` handler now collects the file name / description into a `string[]` without parsing them as markdown.
- `showTooltip` renders each line as a plain text `div` (text node), so the content — including backslashes in Windows paths — is shown verbatim.

The now-unused `parseMarkdown` and `CardBody` imports were removed from this file.

## Testing

- Extended `src/components/__test__/chat-item/chat-item-tree-file.spec.ts` with a test that hovers a tree file whose path is a Windows path and asserts the tooltip contains the path verbatim (backslashes preserved), and does not collapse `discr\.gradle` to `discr.gradle`.
- The test was confirmed to fail against the previous markdown-based rendering and to pass with this change.
- Full unit test suite passes (`npx jest`): 843 tests.
- `eslint` and `prettier --check` pass; production build (`npm run build`) succeeds.

## Additional change

- `ui-tests/__test__/flows/quick-action-commands-header.ts`: coerced the result of a Playwright `evaluate` call to a boolean with `Boolean(...)` to satisfy `@typescript-eslint/strict-boolean-expressions` and keep the repo lint gate green.
