### PR TITLE
fix: render tool summary header and content as one container

### DIFF
--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -457,8 +457,27 @@
                 display: none;
                 flex-flow: column nowrap;
             }
-            &.show-summary > .mynah-chat-item-card-summary-collapsed-content {
-                display: flex;
+            // When expanded, the header and the collapsed content should read as a
+            // single container instead of separate rounded boxes. Square the header's
+            // bottom corners and the content's top corners so they connect, and let the
+            // header's bottom border act as the divider between the header and the
+            // parameters/results below.
+            &.show-summary {
+                > .mynah-chat-item-card-summary-content {
+                    border-bottom-left-radius: 0;
+                    border-bottom-right-radius: 0;
+                }
+                > .mynah-chat-item-card-summary-collapsed-content {
+                    display: flex;
+                    border-right: var(--mynah-border-width) solid var(--mynah-color-border-default);
+                    border-bottom: var(--mynah-border-width) solid var(--mynah-color-border-default);
+                    border-left: var(--mynah-border-width) solid var(--mynah-color-border-default);
+                    border-bottom-left-radius: var(--mynah-card-radius);
+                    border-bottom-right-radius: var(--mynah-card-radius);
+                    // Clip the inner parameter/result cards to the container's shape so
+                    // their own corners do not create separate rounded boxes.
+                    overflow: hidden;
+                }
             }
         }
     }

--- a/ui-tests/__test__/flows/quick-action-commands-header.ts
+++ b/ui-tests/__test__/flows/quick-action-commands-header.ts
@@ -137,9 +137,9 @@ export const verifyQuickActionCommandsHeaderStatusVariations = async (page: Page
   let foundStatusClass = false;
 
   for (const statusClass of statusClasses) {
-    const hasStatus = await headerElement.evaluate((el, className) =>
+    const hasStatus = Boolean(await headerElement.evaluate((el, className) =>
       el.classList.contains(className), statusClass
-    );
+    ));
     if (hasStatus) {
       foundStatusClass = true;
       console.log(`Found status class: ${statusClass}`);


### PR DESCRIPTION
## Problem

When a tool summary (for example an MCP tool call) is expanded in chat, the header ("<tool> ✓ Completed") and the expanded content ("Parameters" and results) render as **separate rounded boxes**. Per the UX spec they should read as a **single container** — the bottom of the header and the top of the content should not be rounded, with a divider between the header and the content.

## Fix

In `src/styles/components/chat/_chat-item-card.scss`, when the summary is expanded (`.show-summary`):

- Square the header's bottom corners (`border-bottom-*-radius: 0`).
- Give the expanded content matching left/right/bottom borders and rounded bottom corners, and `overflow: hidden` so the inner parameter/result cards are clipped to the container shape.
- The header's existing bottom border acts as the divider between the header and the content.

The result is a single bordered container: header on top, a divider, then the parameters/results, with only the outer corners rounded.

## Scope / testing

- Change is scoped entirely to the `.mynah-chat-item-card-summary` styles (the tool-summary component); no other components are affected.
- `npm run build` compiles the styles successfully; full unit suite and `eslint`/`prettier` pass.
- There are no end-to-end screenshot snapshots covering the tool-summary component, so no baselines are affected.
- This is a CSS-only presentation change. I was not able to render it in a live IDE from this environment, so a quick visual sign-off against the design is recommended before marking ready.

## Additional change

- `ui-tests/__test__/flows/quick-action-commands-header.ts`: coerced a Playwright `evaluate` result to a boolean with `Boolean(...)` to satisfy `@typescript-eslint/strict-boolean-expressions` and keep the repo lint gate green.
