### PR TITLE
fix: allow scrolling the sent-to-prompt code attachment

### DIFF
--- a/src/styles/components/chat/_chat-prompt-attachment.scss
+++ b/src/styles/components/chat/_chat-prompt-attachment.scss
@@ -22,6 +22,9 @@
             > .mynah-syntax-highlighter {
                 pointer-events: auto;
                 user-select: text;
+                // Allow scrolling on hover so the full (overflowing) code snippet can be
+                // viewed; without this the content is clipped and no scrollbar is usable.
+                overflow: auto;
                 pre {
                     text-overflow: unset;
                 }
@@ -63,6 +66,10 @@
     > .mynah-card-body {
         > .mynah-syntax-highlighter {
             max-height: calc(70vh - var(--mynah-sizing-12)) !important;
+            // The preview is meant to show the full snippet, so allow it to scroll
+            // (horizontally and vertically) and be interactive.
+            overflow: auto !important;
+            pointer-events: auto !important;
         }
     }
 }

--- a/ui-tests/__test__/flows/quick-action-commands-header.ts
+++ b/ui-tests/__test__/flows/quick-action-commands-header.ts
@@ -137,9 +137,9 @@ export const verifyQuickActionCommandsHeaderStatusVariations = async (page: Page
   let foundStatusClass = false;
 
   for (const statusClass of statusClasses) {
-    const hasStatus = await headerElement.evaluate((el, className) =>
+    const hasStatus = Boolean(await headerElement.evaluate((el, className) =>
       el.classList.contains(className), statusClass
-    );
+    ));
     if (hasStatus) {
       foundStatusClass = true;
       console.log(`Found status class: ${statusClass}`);


### PR DESCRIPTION
## Problem

When code is added to the chat prompt via "Send to prompt" (right‑click → Amazon Q → Send to prompt, or the keyboard shortcut), the code snippet cannot be scrolled: long/wide code is clipped and the horizontal/vertical scrollbars are not usable, so the full code cannot be viewed — in both the inline prompt attachment and its hover preview.

## Root cause

In `src/styles/components/chat/_chat-prompt-attachment.scss`, the snippet's syntax highlighter is styled with `overflow: hidden` (and `pointer-events: none`). On hover the inline attachment sets `pointer-events: auto` but keeps `overflow: hidden`, so there is never a usable scrollbar; the preview overlay inherits the same `overflow: hidden`.

## Fix

- Inline attachment: on `:hover`, set `overflow: auto` on the syntax highlighter so the (already interactive) snippet can be scrolled to view the full code.
- Preview overlay (`.mynah-prompt-input-snippet-attachment-overlay`): set `overflow: auto` and `pointer-events: auto` on the syntax highlighter so the preview scrolls and is interactive.

## Scope / testing

- Change is limited to the prompt code‑attachment styles; the default (non‑hover) inline rendering keeps `overflow: hidden`, so it is visually unchanged.
- `npm run build` compiles the styles; full unit suite, `eslint`, and `prettier --check` pass. No end‑to‑end snapshot covers the hover/overlay state.
- CSS‑only presentation change that I could not render in a live IDE from this environment; a quick visual sign‑off (scroll a long snippet + its preview) is recommended before marking ready.

## Additional change

- `ui-tests/__test__/flows/quick-action-commands-header.ts`: coerced a Playwright `evaluate` result to a boolean to satisfy `@typescript-eslint/strict-boolean-expressions` and keep the repo lint gate green.
