### PR TITLE
fix: update repository URL to the Amazon-Q-Developer org

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "main": "./dist/main.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/mynah-ui"
+        "url": "https://github.com/Amazon-Q-Developer/mynah-ui"
     },
     "scripts": {
         "clean": "npm run clean:dist && npm run clean:node",


### PR DESCRIPTION
## Problem

The repo was transferred from `aws/mynah-ui` to `Amazon-Q-Developer/mynah-ui`, but `repository.url` in `package.json` still points at the old org.

Publishing uses OIDC trusted publishing (`id-token: write` in `publish.yml`, no stored npm token) and the package carries SLSA provenance attestations. npm validates `repository.url` against the OIDC claims of the building repository when generating provenance, so a stale URL fails the publish step. npm also derives the displayed homepage from this field, which currently shows `github.com/aws/mynah-ui#readme`.

## Solution

Point `repository.url` at the new org. One line.

Deliberately out of scope:

- The `@aws/mynah-ui` package name — that is the npm scope, unrelated to the GitHub org, and renaming it would break every consumer.
- The 35 remaining `github.com/aws/mynah-ui` documentation and demo links across `docs/`, `example/` and `ui-tests/`. They redirect, and several in `ui-tests/__test__/flows/markdown-parser/` are test fixtures where the URL is parser input, so changing them risks breaking assertions for no publishing benefit. Worth a separate docs-only pass.

## Testing

`prettier --check` passes and JSON validity confirmed. No build impact — `repository.url` is registry metadata and is not read by TypeScript or the bundler.

## Also needed before the next release

The npm **trusted publisher** config for `@aws/mynah-ui` still names the `aws` GitHub org and must be repointed to `Amazon-Q-Developer`. Both that and this change are required: the trusted publisher match gates the publish, and `repository.url` gates provenance generation within it.
